### PR TITLE
example: added tags example

### DIFF
--- a/mapstructure_examples_test.go
+++ b/mapstructure_examples_test.go
@@ -165,5 +165,5 @@ func ExampleDecode_tags() {
 
 	fmt.Printf("%#v", result)
 	// Output:
-	// main.Person{Name:"Mitchell", Age:91}
+	// mapstructure.Person{Name:"Mitchell", Age:91}
 }


### PR DESCRIPTION
Added an example to demonstrate how struct tags can be used with mapstructure.

Motivation came from #13.
