### PR TITLE
Fix decodeSlice to check input type before calling its Len method

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -470,22 +470,22 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 	dataValKind := dataVal.Kind()
 	valType := val.Type()
 	valElemType := valType.Elem()
-
-	// Make a new slice to hold our result, same size as the original data.
 	sliceType := reflect.SliceOf(valElemType)
-	valSlice := reflect.MakeSlice(sliceType, dataVal.Len(), dataVal.Len())
 
 	// Check input type
 	if dataValKind != reflect.Array && dataValKind != reflect.Slice {
 		// Accept empty map instead of array/slice in weakly typed mode
 		if d.config.WeaklyTypedInput && dataVal.Kind() == reflect.Map && dataVal.Len() == 0 {
-			val.Set(valSlice)
+			val.Set(reflect.MakeSlice(sliceType, 0, 0))
 			return nil
 		} else {
 			return fmt.Errorf(
 				"'%s': source data must be an array or slice, got %s", name, dataValKind)
 		}
 	}
+
+	// Make a new slice to hold our result, same size as the original data.
+	valSlice := reflect.MakeSlice(sliceType, dataVal.Len(), dataVal.Len())
 
 	// Accumulate any errors
 	errors := make([]string, 0)

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -593,6 +593,21 @@ func TestSlice(t *testing.T) {
 	testSliceInput(t, inputStringSlicePointer, outputStringSlice)
 }
 
+func TestInvalidSlice(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"vfoo": "foo",
+		"vbar": 42,
+	}
+
+	result := Slice{}
+	err := Decode(input, &result)
+	if err == nil {
+		t.Errorf("expected failure")
+	}
+}
+
 func TestSliceOfStruct(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
In `decodeSlice`, the type of `data` isn't checked before calling `dataVal.Len()`, and `reflect.Value.Len` panics when the value doesn't have a length. So, `decodeSlice` panics if I pass integer values or something like that to it. I added a test code as an example case.
