### PR TITLE
Fix tests when using Go 1.3

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -462,6 +462,7 @@ func (d *Decoder) decodeMap(name string, data interface{}, val reflect.Value) er
 
 	// If we had errors, return those
 	if len(errors) > 0 {
+		sort.Strings(errors)
 		return &Error{errors}
 	}
 
@@ -522,6 +523,7 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 
 	// If there were errors, we return those
 	if len(errors) > 0 {
+		sort.Strings(errors)
 		return &Error{errors}
 	}
 
@@ -670,6 +672,7 @@ func (d *Decoder) decodeStruct(name string, data interface{}, val reflect.Value)
 	}
 
 	if len(errors) > 0 {
+		sort.Strings(errors)
 		return &Error{errors}
 	}
 

--- a/mapstructure_examples_test.go
+++ b/mapstructure_examples_test.go
@@ -62,11 +62,11 @@ func ExampleDecode_errors() {
 	// Output:
 	// 5 error(s) decoding:
 	//
-	// * 'Name' expected type 'string', got unconvertible type 'int'
 	// * 'Age' expected type 'int', got unconvertible type 'string'
 	// * 'Emails[0]' expected type 'string', got unconvertible type 'int'
 	// * 'Emails[1]' expected type 'string', got unconvertible type 'int'
 	// * 'Emails[2]' expected type 'string', got unconvertible type 'int'
+	// * 'Name' expected type 'string', got unconvertible type 'int'
 }
 
 func ExampleDecode_metadata() {

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -690,7 +690,8 @@ func TestMetadata(t *testing.T) {
 		t.Fatalf("err: %s", err.Error())
 	}
 
-	expectedKeys := []string{"Vfoo", "Vbar.Vstring", "Vbar.Vuint", "Vbar"}
+	sort.Strings(md.Keys)
+	expectedKeys := []string{"Vbar", "Vbar.Vstring", "Vbar.Vuint", "Vfoo"}
 	if !reflect.DeepEqual(md.Keys, expectedKeys) {
 		t.Fatalf("bad keys: %#v", md.Keys)
 	}


### PR DESCRIPTION
In Go 1.3 the iteration order of short maps is random. In previous
version the order was maintained. This caused tests that rely on the
order to fail.