### PR TITLE
Add squash example

### DIFF
--- a/mapstructure_examples_test.go
+++ b/mapstructure_examples_test.go
@@ -167,3 +167,37 @@ func ExampleDecode_tags() {
 	// Output:
 	// mapstructure.Person{Name:"Mitchell", Age:91}
 }
+
+func ExampleDecode_embeddedStruct() {
+	// Squashing multiple embedded structs is allowed using the squash tag.
+	// This is demonstrated by creating a composite struct of multiple types
+	// and decoding into it. In this case, a person can carry with it both
+	// a Family and a Location, as well as their own FirstName.
+	type Family struct {
+		LastName string
+	}
+	type Location struct {
+		City string
+	}
+	type Person struct {
+		Family    `mapstructure:",squash"`
+		Location  `mapstructure:",squash"`
+		FirstName string
+	}
+
+	input := map[string]interface{}{
+		"FirstName": "Mitchell",
+		"LastName":  "Hashimoto",
+		"City":      "San Francisco",
+	}
+
+	var result Person
+	err := Decode(input, &result)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s %s, %s", result.FirstName, result.LastName, result.City)
+	// Output:
+	// Mitchell Hashimoto, San Francisco
+}


### PR DESCRIPTION
Adds an example using the existing `squash` tag to pull in embedded struct fields.
Fixes #19.