### PR TITLE
tests: fix nondeterministic failures

### DIFF
--- a/error.go
+++ b/error.go
@@ -2,6 +2,7 @@ package mapstructure
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -16,6 +17,8 @@ func (e *Error) Error() string {
 	for i, err := range e.Errors {
 		points[i] = fmt.Sprintf("* %s", err)
 	}
+
+	sort.Strings(points)
 
 	return fmt.Sprintf(
 		"%d error(s) decoding:\n\n%s",

--- a/mapstructure_examples_test.go
+++ b/mapstructure_examples_test.go
@@ -62,11 +62,11 @@ func ExampleDecode_errors() {
 	// Output:
 	// 5 error(s) decoding:
 	//
-	// * 'Name' expected type 'string', got unconvertible type 'int'
 	// * 'Age' expected type 'int', got unconvertible type 'string'
 	// * 'Emails[0]' expected type 'string', got unconvertible type 'int'
 	// * 'Emails[1]' expected type 'string', got unconvertible type 'int'
 	// * 'Emails[2]' expected type 'string', got unconvertible type 'int'
+	// * 'Name' expected type 'string', got unconvertible type 'int'
 }
 
 func ExampleDecode_metadata() {

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -691,8 +691,10 @@ func TestMetadata(t *testing.T) {
 	}
 
 	expectedKeys := []string{"Vfoo", "Vbar.Vstring", "Vbar.Vuint", "Vbar"}
+	sort.Strings(expectedKeys)
+	sort.Strings(md.Keys)
 	if !reflect.DeepEqual(md.Keys, expectedKeys) {
-		t.Fatalf("bad keys: %#v", md.Keys)
+		t.Fatalf("expected keys: %#v\nbad keys: %#v", expectedKeys, md.Keys)
 	}
 
 	expectedUnused := []string{"Vbar.foo", "bar"}


### PR DESCRIPTION
map iteration in golang does not happen in a deterministic order:

https://golang.org/doc/go1.3#map

this means we needed to proactively sort stuff in two places:

 * key checking in one of our tests
 * errors output from the decoder

now our tests are passing the first time, every time (tm).