### PR TITLE
Use struct directly if type matches

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -530,6 +530,12 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 
 func (d *Decoder) decodeStruct(name string, data interface{}, val reflect.Value) error {
 	dataVal := reflect.Indirect(reflect.ValueOf(data))
+
+	if dataVal.Type() == val.Type() {
+		val.Set(dataVal)
+		return nil
+	}
+
 	dataValKind := dataVal.Kind()
 	if dataValKind != reflect.Map {
 		return fmt.Errorf("'%s' expected a map, got '%s'", name, dataValKind)


### PR DESCRIPTION
Right now when using the decodeHook to build custom structs, I have to build a map that will later be decoded. I can't build my struct directly because it will throw the "'%s' expected a map, got '%s'" error.

This commit fixes it by using the struct without any decoding if src and dest types matche