### PR TITLE
Send reflect.Type instead of reflect.Kind to hook functions

### DIFF
--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -13,8 +13,8 @@ import (
 // previous transformation.
 func ComposeDecodeHookFunc(fs ...DecodeHookFunc) DecodeHookFunc {
 	return func(
-		f reflect.Kind,
-		t reflect.Kind,
+		f reflect.Type,
+		t reflect.Type,
 		data interface{}) (interface{}, error) {
 		var err error
 		for _, f1 := range fs {
@@ -24,7 +24,7 @@ func ComposeDecodeHookFunc(fs ...DecodeHookFunc) DecodeHookFunc {
 			}
 
 			// Modify the from kind to be correct with the new data
-			f = getKind(reflect.ValueOf(data))
+			f = reflect.ValueOf(data).Type()
 		}
 
 		return data, nil
@@ -35,10 +35,10 @@ func ComposeDecodeHookFunc(fs ...DecodeHookFunc) DecodeHookFunc {
 // string to []string by splitting on the given sep.
 func StringToSliceHookFunc(sep string) DecodeHookFunc {
 	return func(
-		f reflect.Kind,
-		t reflect.Kind,
+		f reflect.Type,
+		t reflect.Type,
 		data interface{}) (interface{}, error) {
-		if f != reflect.String || t != reflect.Slice {
+		if f.Kind() != reflect.String || t.Kind() != reflect.Slice {
 			return data, nil
 		}
 
@@ -52,13 +52,13 @@ func StringToSliceHookFunc(sep string) DecodeHookFunc {
 }
 
 func WeaklyTypedHook(
-	f reflect.Kind,
-	t reflect.Kind,
+	f reflect.Type,
+	t reflect.Type,
 	data interface{}) (interface{}, error) {
 	dataVal := reflect.ValueOf(data)
-	switch t {
+	switch t.Kind() {
 	case reflect.String:
-		switch f {
+		switch f.Kind() {
 		case reflect.Bool:
 			if dataVal.Bool() {
 				return "1", nil

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -20,8 +20,8 @@ import (
 // data transformations. See "DecodeHook" in the DecoderConfig
 // struct.
 type DecodeHookFunc func(
-	from reflect.Kind,
-	to reflect.Kind,
+	from reflect.Type,
+	to reflect.Type,
 	data interface{}) (interface{}, error)
 
 // DecoderConfig is the configuration that is used to create a new decoder
@@ -180,7 +180,7 @@ func (d *Decoder) decode(name string, data interface{}, val reflect.Value) error
 	if d.config.DecodeHook != nil {
 		// We have a DecodeHook, so let's pre-process the data.
 		var err error
-		data, err = d.config.DecodeHook(getKind(dataVal), getKind(val), data)
+		data, err = d.config.DecodeHook(dataVal.Type(), val.Type(), data)
 		if err != nil {
 			return err
 		}

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -232,8 +232,8 @@ func TestDecode_DecodeHook(t *testing.T) {
 		"vint": "WHAT",
 	}
 
-	decodeHook := func(from reflect.Kind, to reflect.Kind, v interface{}) (interface{}, error) {
-		if from == reflect.String && to != reflect.String {
+	decodeHook := func(from reflect.Type, to reflect.Type, v interface{}) (interface{}, error) {
+		if from.Kind() == reflect.String && to.Kind() != reflect.String {
 			return 5, nil
 		}
 


### PR DESCRIPTION
For structs, reflect.Kind is not enough : it doesn't let us know which kind of struct is expected.
With reflect.Type we get more information about src and dest.

It allows for example in the hook to do something like this :
```
if to == reflect.TypeOf(time.Time{}) {
  data = time.Parse([...])
}
```