### PR TITLE
Don't decode negative numbers to overflowed uints

### DIFF
--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -658,6 +658,42 @@ func TestInvalidType(t *testing.T) {
 	if derr.Errors[0] != "'Vstring' expected type 'string', got unconvertible type 'int'" {
 		t.Errorf("got unexpected error: %s", err)
 	}
+
+	inputNegIntUint := map[string]interface{}{
+		"vuint": -42,
+	}
+
+	err = Decode(inputNegIntUint, &result)
+	if err == nil {
+		t.Fatal("error should exist")
+	}
+
+	derr, ok = err.(*Error)
+	if !ok {
+		t.Fatalf("error should be kind of Error, instead: %#v", err)
+	}
+
+	if derr.Errors[0] != "cannot parse 'Vuint', -42 overflows uint" {
+		t.Errorf("got unexpected error: %s", err)
+	}
+
+	inputNegFloatUint := map[string]interface{}{
+		"vuint": -42.0,
+	}
+
+	err = Decode(inputNegFloatUint, &result)
+	if err == nil {
+		t.Fatal("error should exist")
+	}
+
+	derr, ok = err.(*Error)
+	if !ok {
+		t.Fatalf("error should be kind of Error, instead: %#v", err)
+	}
+
+	if derr.Errors[0] != "cannot parse 'Vuint', -42.000000 overflows uint" {
+		t.Errorf("got unexpected error: %s", err)
+	}
 }
 
 func TestMetadata(t *testing.T) {


### PR DESCRIPTION
Trying to decode negative numbers to `uint` types results in overflowed values. Since trying to do this normally will result in an `error`, it stands to reason that this library should do the same. 

I've left the case that if `WeaklyTypedInput` is set, then the status quo remains, but I could definitely see a case for overriding that.