### PR TITLE
Add package-level functions for decoding with metadata

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -104,6 +104,40 @@ type Metadata struct {
 	Unused []string
 }
 
+// DecodeMetadata is the same as Decode, but is shorthand to
+// enable metadata collection. See DecoderConfig for more info.
+func DecodeMetadata(input interface{}, output interface{}, metadata *Metadata) error {
+	config := &DecoderConfig{
+		Metadata: metadata,
+		Result:   output,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(input)
+}
+
+// WeakDecodeMetadata is the same as Decode, but is shorthand to
+// enable both WeaklyTypedInput and metadata collection. See
+// DecoderConfig for more info.
+func WeakDecodeMetadata(input interface{}, output interface{}, metadata *Metadata) error {
+	config := &DecoderConfig{
+		Metadata:         metadata,
+		Result:           output,
+		WeaklyTypedInput: true,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(input)
+}
+
 // Decode takes a map and uses reflection to convert it into the
 // given Go native structure. val must be a pointer to a struct.
 func Decode(m interface{}, rawVal interface{}) error {

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -138,12 +138,12 @@ func WeakDecodeMetadata(input interface{}, output interface{}, metadata *Metadat
 	return decoder.Decode(input)
 }
 
-// Decode takes a map and uses reflection to convert it into the
-// given Go native structure. val must be a pointer to a struct.
-func Decode(m interface{}, rawVal interface{}) error {
+// Decode takes a map, input, and uses reflection to convert it into the
+// given Go native structure. output must be a pointer to a struct.
+func Decode(input interface{}, output interface{}) error {
 	config := &DecoderConfig{
 		Metadata: nil,
-		Result:   rawVal,
+		Result:   output,
 	}
 
 	decoder, err := NewDecoder(config)
@@ -151,7 +151,7 @@ func Decode(m interface{}, rawVal interface{}) error {
 		return err
 	}
 
-	return decoder.Decode(m)
+	return decoder.Decode(input)
 }
 
 // WeakDecode is the same as Decode but is shorthand to enable


### PR DESCRIPTION
A common use case for mapstructure seems to be decoding and then ensuring that some minimum subset of keys was present (when parsing configuration where there are no sensible defaults for example).

This PR adds package level functions matching `Decode` and `WeakDecode` which also take a pointer to a `Metadata` structure, in order to reduce the amount of boilerplate consumers need to implement this. It reduces the consumer code from:

``` go
    var result Config
    var metadata mapstructure.Metadata
    decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
        Metadata: &metadata,
        Result: &result,
    })
    if err != nil {
        return nil, err
    }
    if err := decoder.Decode(hclMap); err != nil {
        return nil, err
    }
```

to:

``` go
    var result Config
    var metadata mapstructure.Metadata
    if err := mapstructure.DecodeMetadata(hclMap, &result, &metadata); err != nil {
        return nil, err
    }
```

The reduction for using weak decoding with metadata is similar. Each new function has a corresponding test.

A second commit makes the parameter names for `Decode` match the parameter names for `WeakDecode` which is clearer when viewing just the function signature (`input`/`output` vs `m`/`rawVal`).
