### PR TITLE
[bug-fix] squash: validate type of sqashed fields also

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -623,11 +623,12 @@ func (d *Decoder) decodeStruct(name string, data interface{}, val reflect.Value)
 		structs = structs[1:]
 
 		structType := structVal.Type()
+
 		for i := 0; i < structType.NumField(); i++ {
 			fieldType := structType.Field(i)
+			fieldKind := fieldType.Type.Kind()
 
 			if fieldType.Anonymous {
-				fieldKind := fieldType.Type.Kind()
 				if fieldKind != reflect.Struct {
 					errors = appendErrors(errors,
 						fmt.Errorf("%s: unsupported type: %s", fieldType.Name, fieldKind))
@@ -646,7 +647,12 @@ func (d *Decoder) decodeStruct(name string, data interface{}, val reflect.Value)
 			}
 
 			if squash {
-				structs = append(structs, val.FieldByName(fieldType.Name))
+				if fieldKind != reflect.Struct {
+					errors = appendErrors(errors,
+						fmt.Errorf("%s: unsupported type for squash: %s", fieldType.Name, fieldKind))
+				} else {
+					structs = append(structs, val.FieldByName(fieldType.Name))
+				}
 				continue
 			}
 

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -3,6 +3,7 @@ package mapstructure
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -34,6 +35,10 @@ type EmbeddedPointer struct {
 type EmbeddedSquash struct {
 	Basic   `mapstructure:",squash"`
 	Vunique string
+}
+
+type SquashOnNonStructType struct {
+	InvalidSquashType int `mapstructure:",squash"`
 }
 
 type Map struct {
@@ -267,6 +272,22 @@ func TestDecode_EmbeddedSquash(t *testing.T) {
 
 	if result.Vunique != "bar" {
 		t.Errorf("vunique value should be 'bar': %#v", result.Vunique)
+	}
+}
+
+func TestDecode_SquashOnNonStructType(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"InvalidSquashType": 42,
+	}
+
+	var result SquashOnNonStructType
+	err := Decode(input, &result)
+	if err == nil {
+		t.Fatal("unexpected success decoding invalid squash field type")
+	} else if !strings.Contains(err.Error(), "unsupported type for squash") {
+		t.Fatalf("unexpected error message for invalid squash field type: %s", err)
 	}
 }
 


### PR DESCRIPTION
If the user adds a 'squash' tag to a non-struct type, the call to
structType.NumField() will silently fail, the application stops.

Fixed by adding an error if the squashed field's type is not struct.