### PR TITLE
Avoid empty slices from StringToSliceHookFunc

### DIFF
--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -98,7 +98,7 @@ func StringToSliceHookFunc(sep string) DecodeHookFunc {
 			return []string{}, nil
 		}
 
-		return strings.Split(raw, sep), nil
+		return strings.Split(strings.Trim(raw, sep), sep), nil
 	}
 }
 


### PR DESCRIPTION
In various use cases the separator will always also be at the end of the string, resulting in an empty slice.