### PR TITLE
Allow decoding a raw string to a string slice

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -588,8 +588,12 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 		// Check input type
 		if dataValKind != reflect.Array && dataValKind != reflect.Slice {
 			// Accept empty map instead of array/slice in weakly typed mode
-			if d.config.WeaklyTypedInput && dataVal.Kind() == reflect.Map && dataVal.Len() == 0 {
+			if d.config.WeaklyTypedInput && dataValKind == reflect.Map && dataVal.Len() == 0 {
 				val.Set(reflect.MakeSlice(sliceType, 0, 0))
+				return nil
+			} else if d.config.WeaklyTypedInput && dataValKind == reflect.String {
+				slc := []string{dataVal.String()}
+				val.Set(reflect.ValueOf(slc))
 				return nil
 			} else {
 				return fmt.Errorf(

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -118,6 +118,7 @@ type TypeConversionResult struct {
 	StringToFloat      float32
 	SliceToMap         map[string]interface{}
 	MapToSlice         []interface{}
+	StringToSlice      []string
 }
 
 func TestBasicTypes(t *testing.T) {
@@ -586,6 +587,7 @@ func TestDecode_TypeConversion(t *testing.T) {
 		"StringToFloat":      "42.42",
 		"SliceToMap":         []interface{}{},
 		"MapToSlice":         map[string]interface{}{},
+		"StringToSlice":      "42",
 	}
 
 	expectedResultStrict := TypeConversionResult{
@@ -624,6 +626,7 @@ func TestDecode_TypeConversion(t *testing.T) {
 		StringToFloat:      42.42,
 		SliceToMap:         map[string]interface{}{},
 		MapToSlice:         []interface{}{},
+		StringToSlice:      []string{"42"},
 	}
 
 	// Test strict type conversion
@@ -954,6 +957,30 @@ func TestSliceToMap(t *testing.T) {
 		"foo": "bar",
 		"bar": "baz",
 	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("bad: %#v", result)
+	}
+}
+
+func TestStringToSlice(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]string{
+		"foo": "bar",
+		"bar": "baz",
+	}
+
+	expected := map[string][]string{
+		"foo": {"bar"},
+		"bar": {"baz"},
+	}
+
+	var result map[string][]string
+
+	if err := WeakDecode(input, &result); err != nil {
+		t.Fatalf("got an error: %s", err)
+	}
+
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("bad: %#v", result)
 	}


### PR DESCRIPTION
If the input is weakly typed, allow decoding a raw string into a string slice, if the desired value is a slice.

```
$ go test ./...
ok      github.com/mitchellh/mapstructure       0.003s
```

```
=== RUN   TestStringToSlice
--- PASS: TestStringToSlice (0.00s)
```