### PR TITLE
Promote single values to slice values for weakly typed input

### DIFF
--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -116,6 +116,8 @@ type TypeConversionResult struct {
 	StringToUint       uint
 	StringToBool       bool
 	StringToFloat      float32
+	StringToStrSlice   []string
+	StringToIntSlice   []int
 	SliceToMap         map[string]interface{}
 	MapToSlice         []interface{}
 }
@@ -584,6 +586,8 @@ func TestDecode_TypeConversion(t *testing.T) {
 		"StringToUint":       "42",
 		"StringToBool":       "1",
 		"StringToFloat":      "42.42",
+		"StringToStrSlice":   "A",
+		"StringToIntSlice":   "42",
 		"SliceToMap":         []interface{}{},
 		"MapToSlice":         map[string]interface{}{},
 	}
@@ -622,6 +626,8 @@ func TestDecode_TypeConversion(t *testing.T) {
 		StringToUint:       42,
 		StringToBool:       true,
 		StringToFloat:      42.42,
+		StringToStrSlice:   []string{"A"},
+		StringToIntSlice:   []int{42},
 		SliceToMap:         map[string]interface{}{},
 		MapToSlice:         []interface{}{},
 	}


### PR DESCRIPTION
This automatically promotes single standalone values to slices/arrays
if the target type is a slice or array. This only happens in weakly
typed mode.

The single value is weakly decoded into the target slice type, meaning
that a string value can decode to an int slice for example.

This enables the following to decode:

```
source := map[string]interface{}{"key": "4"}

var target struct {
  Key []int
}

// Decode source to target

// Pseudocode
result == { Key: []int{4} }
```