### PR TITLE
Feature: Decode structs to maps

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -501,7 +501,60 @@ func (d *Decoder) decodeMap(name string, data interface{}, val reflect.Value) er
 
 	// Check input type
 	dataVal := reflect.Indirect(reflect.ValueOf(data))
-	if dataVal.Kind() != reflect.Map {
+	if dataVal.Kind() == reflect.Struct {
+		typ := dataVal.Type()
+		for i := 0; i < typ.NumField(); i++ {
+			v := dataVal.Field(i)
+			if !v.Type().AssignableTo(valMap.Type().Elem()) {
+				return fmt.Errorf("cannot assign type '%s' to map value field of type '%s'", v.Type(), valMap.Type().Elem())
+			}
+
+			f := typ.Field(i)
+
+			keyName := f.Name
+
+			tagValue := f.Tag.Get(d.config.TagName)
+			tagValue = strings.SplitN(tagValue, ",", 2)[0]
+			if tagValue != "" {
+				if tagValue == "-" {
+					continue
+				}
+
+				keyName = tagValue
+			}
+
+			switch v.Kind() {
+			// this is an embedded struct, so handle it differently
+			case reflect.Struct:
+				x := reflect.New(v.Type())
+				x.Elem().Set(v)
+
+				vType := valMap.Type()
+				vKeyType := vType.Key()
+				vElemType := vType.Elem()
+				mType := reflect.MapOf(vKeyType, vElemType)
+				vMap := reflect.MakeMap(mType)
+
+				err := d.decode(keyName, x.Interface(), vMap)
+				if err != nil {
+					return err
+				}
+
+				valMap.SetMapIndex(reflect.ValueOf(keyName), vMap)
+
+			default:
+				if v.CanSet() {
+					valMap.SetMapIndex(reflect.ValueOf(keyName), v)
+				}
+			}
+		}
+
+		if valMap.CanAddr() {
+			val.Set(valMap)
+		}
+
+		return nil
+	} else if dataVal.Kind() != reflect.Map {
 		// In weak mode, we accept a slice of maps as an input...
 		if d.config.WeaklyTypedInput {
 			switch dataVal.Kind() {

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -1366,3 +1366,192 @@ func testArrayInput(t *testing.T, input map[string]interface{}, expected *Array)
 		}
 	}
 }
+
+func TestMapOutputForStructuredInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      interface{}
+		target  interface{}
+		out     interface{}
+		wantErr bool
+	}{
+		{
+			"basic struct input",
+			&Basic{
+				Vstring: "vstring",
+				Vint:    2,
+				Vuint:   3,
+				Vbool:   true,
+				Vfloat:  4.56,
+				Vextra:  "vextra",
+				vsilent: true,
+				Vdata:   []byte("data"),
+			},
+			&map[string]interface{}{},
+			&map[string]interface{}{
+				"Vstring":     "vstring",
+				"Vint":        2,
+				"Vuint":       uint(3),
+				"Vbool":       true,
+				"Vfloat":      4.56,
+				"Vextra":      "vextra",
+				"Vdata":       []byte("data"),
+				"VjsonInt":    0,
+				"VjsonFloat":  0.0,
+				"VjsonNumber": json.Number(""),
+			},
+			false,
+		},
+		{
+			"embedded struct input",
+			&Embedded{
+				Vunique: "vunique",
+				Basic: Basic{
+					Vstring: "vstring",
+					Vint:    2,
+					Vuint:   3,
+					Vbool:   true,
+					Vfloat:  4.56,
+					Vextra:  "vextra",
+					vsilent: true,
+					Vdata:   []byte("data"),
+				},
+			},
+			&map[string]interface{}{},
+			&map[string]interface{}{
+				"Vunique": "vunique",
+				"Basic": map[string]interface{}{
+					"Vstring":     "vstring",
+					"Vint":        2,
+					"Vuint":       uint(3),
+					"Vbool":       true,
+					"Vfloat":      4.56,
+					"Vextra":      "vextra",
+					"Vdata":       []byte("data"),
+					"VjsonInt":    0,
+					"VjsonFloat":  0.0,
+					"VjsonNumber": json.Number(""),
+				},
+			},
+			false,
+		},
+		{
+			"slice input - should error",
+			[]string{"foo", "bar"},
+			&map[string]interface{}{},
+			&map[string]interface{}{},
+			true,
+		},
+		{
+			"struct with slice property",
+			&Slice{
+				Vfoo: "vfoo",
+				Vbar: []string{"foo", "bar"},
+			},
+			&map[string]interface{}{},
+			&map[string]interface{}{
+				"Vfoo": "vfoo",
+				"Vbar": []string{"foo", "bar"},
+			},
+			false,
+		},
+		{
+			"struct with slice of struct property",
+			&SliceOfStruct{
+				Value: []Basic{
+					Basic{
+						Vstring: "vstring",
+						Vint:    2,
+						Vuint:   3,
+						Vbool:   true,
+						Vfloat:  4.56,
+						Vextra:  "vextra",
+						vsilent: true,
+						Vdata:   []byte("data"),
+					},
+				},
+			},
+			&map[string]interface{}{},
+			&map[string]interface{}{
+				"Value": []Basic{
+					Basic{
+						Vstring: "vstring",
+						Vint:    2,
+						Vuint:   3,
+						Vbool:   true,
+						Vfloat:  4.56,
+						Vextra:  "vextra",
+						vsilent: true,
+						Vdata:   []byte("data"),
+					},
+				},
+			},
+			false,
+		},
+		{
+			"struct with map property",
+			&Map{
+				Vfoo:   "vfoo",
+				Vother: map[string]string{"vother": "vother"},
+			},
+			&map[string]interface{}{},
+			&map[string]interface{}{
+				"Vfoo": "vfoo",
+				"Vother": map[string]string{
+					"vother": "vother",
+				}},
+			false,
+		},
+		{
+			"tagged struct",
+			&Tagged{
+				Extra: "extra",
+				Value: "value",
+			},
+			&map[string]string{},
+			&map[string]string{
+				"bar": "extra",
+				"foo": "value",
+			},
+			false,
+		},
+		{
+			"omit tag struct",
+			&struct {
+				Value string `mapstructure:"value"`
+				Omit  string `mapstructure:"-"`
+			}{
+				Value: "value",
+				Omit:  "omit",
+			},
+			&map[string]string{},
+			&map[string]string{
+				"value": "value",
+			},
+			false,
+		},
+		{
+			"decode to wrong map type",
+			&struct {
+				Value string
+			}{
+				Value: "string",
+			},
+			&map[string]int{},
+			&map[string]int{},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		if err := Decode(tt.in, tt.target); (err != nil) != tt.wantErr {
+			t.Fatalf("%q: TestMapOutputForStructuredInputs() unexpected error: %s", tt.name, err)
+		}
+
+		if !reflect.DeepEqual(tt.out, tt.target) {
+			t.Fatalf("%q: TestMapOutputForStructuredInputs() expected: %#v, got: %#v", tt.name, tt.out, tt.target)
+		}
+	}
+}


### PR DESCRIPTION
This feature adds the ability to decode structs to maps (essentially allowing the converse of the conventional use of this library). I've tried to be as complete in the test cases that I could add. 

One thing this doesn't do (yet) is map structs recursively. I'm not sure if this library should even do that, the containers for those inner structs can't really be supplied elegantly. If this was to be done - and i'd be happy to do it if that's the case, all structs would be initialized and decoded to `map[string]interface{}`. What do you think @mitchellh?

Closes #53 