### PR TITLE
Fix golint warnings

### DIFF
--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -121,6 +121,11 @@ func StringToTimeDurationHookFunc() DecodeHookFunc {
 	}
 }
 
+// WeaklyTypedHook is a DecodeHookFunc which adds support for weak typing to
+// the decoder.
+//
+// Note that this is significantly different from the WeaklyTypedInput option
+// of the DecoderConfig.
 func WeaklyTypedHook(
 	f reflect.Kind,
 	t reflect.Kind,
@@ -132,9 +137,8 @@ func WeaklyTypedHook(
 		case reflect.Bool:
 			if dataVal.Bool() {
 				return "1", nil
-			} else {
-				return "0", nil
 			}
+			return "0", nil
 		case reflect.Float32:
 			return strconv.FormatFloat(dataVal.Float(), 'f', -1, 64), nil
 		case reflect.Int:

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -1,5 +1,5 @@
-// The mapstructure package exposes functionality to convert an
-// arbitrary map[string]interface{} into a native Go structure.
+// Package mapstructure exposes functionality to convert an arbitrary
+// map[string]interface{} into a native Go structure.
 //
 // The Go structure can be arbitrarily complex, containing slices,
 // other structs, etc. and the decoder will properly decode nested
@@ -32,7 +32,12 @@ import (
 // both.
 type DecodeHookFunc interface{}
 
+// DecodeHookFuncType is a DecodeHookFunc which has complete information about
+// the source and target types.
 type DecodeHookFuncType func(reflect.Type, reflect.Type, interface{}) (interface{}, error)
+
+// DecodeHookFuncKind is a DecodeHookFunc which knows only the Kinds of the
+// source and target types.
 type DecodeHookFuncKind func(reflect.Kind, reflect.Kind, interface{}) (interface{}, error)
 
 // DecoderConfig is the configuration that is used to create a new decoder
@@ -436,7 +441,7 @@ func (d *Decoder) decodeFloat(name string, data interface{}, val reflect.Value) 
 	case dataKind == reflect.Uint:
 		val.SetFloat(float64(dataVal.Uint()))
 	case dataKind == reflect.Float32:
-		val.SetFloat(float64(dataVal.Float()))
+		val.SetFloat(dataVal.Float())
 	case dataKind == reflect.Bool && d.config.WeaklyTypedInput:
 		if dataVal.Bool() {
 			val.SetFloat(1)

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -437,7 +437,7 @@ func TestDecode_DecodeHookType(t *testing.T) {
 func TestDecode_Nil(t *testing.T) {
 	t.Parallel()
 
-	var input interface{} = nil
+	var input interface{}
 	result := Basic{
 		Vstring: "foo",
 	}


### PR DESCRIPTION
This fixes all warnings reported by golint for this codebase and an
unnecessary type cast in mapdecode.go.