### PR TITLE
Add configuration for forcing case-sensitive key/tag matches in decoding.

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -43,6 +43,11 @@ type DecodeHookFuncKind func(reflect.Kind, reflect.Kind, interface{}) (interface
 // DecoderConfig is the configuration that is used to create a new decoder
 // and allows customization of various aspects of decoding.
 type DecoderConfig struct {
+	// CaseSensitiveKeys, if set to true, will only compare keys by
+	// exact Unicode matches.  If false, keys will be compared by
+	// Unicode case-folding.
+	CaseSensitiveKeys bool
+
 	// DecodeHook, if set, will be called before any decoding and any
 	// type conversion (if WeaklyTypedInput is on). This lets you modify
 	// the values before they're set down onto the resulting struct.
@@ -734,6 +739,11 @@ func (d *Decoder) decodeStruct(name string, data interface{}, val reflect.Value)
 		rawMapKey := reflect.ValueOf(fieldName)
 		rawMapVal := dataVal.MapIndex(rawMapKey)
 		if !rawMapVal.IsValid() {
+			// If we only allow case-sensitive keys, there's no matching key
+			// in the map.  Just ignore.
+			if d.config.CaseSensitiveKeys {
+				continue
+			}
 			// Do a slower search by iterating over each key and
 			// doing case-insensitive search.
 			for dataValKey := range dataValKeys {

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -666,6 +666,130 @@ func TestDecode_TypeConversion(t *testing.T) {
 	}
 }
 
+func TestDecoder_CaseSensitiveKeys_NoTagsNoMatches(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"vstring": "hello",
+		"foo":     "bar",
+	}
+
+	var result Basic
+	var metadata Metadata
+	config := &DecoderConfig{
+		CaseSensitiveKeys: true,
+		Metadata:          &metadata,
+		Result:            &result,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = decoder.Decode(input)
+	if err != nil {
+		t.Fatalf("got an err: %s", err)
+	}
+
+	if len(metadata.Unused) != 2 {
+		t.Errorf("expected 2 unused keys, got %d.", len(metadata.Unused))
+	}
+}
+
+func TestDecoder_CaseSensitiveKeys_NoTagsAllMatches(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"Vstring":  "hello",
+		"VjsonInt": 3,
+	}
+
+	var result Basic
+	var metadata Metadata
+	config := &DecoderConfig{
+		CaseSensitiveKeys: true,
+		Metadata:          &metadata,
+		Result:            &result,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = decoder.Decode(input)
+	if err != nil {
+		t.Fatalf("got an err: %s", err)
+	}
+
+	if len(metadata.Unused) != 0 {
+		t.Errorf("expected 0 unused keys, got %d.", len(metadata.Unused))
+	}
+}
+
+func TestDecoder_CaseSensitiveKeys_WithTagsNoMatches(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"Extra": "hello",
+		"Value": "there",
+	}
+
+	var result Tagged
+	var metadata Metadata
+	config := &DecoderConfig{
+		CaseSensitiveKeys: true,
+		Metadata:          &metadata,
+		Result:            &result,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = decoder.Decode(input)
+	if err != nil {
+		t.Fatalf("got an err: %s", err)
+	}
+
+	if len(metadata.Unused) != 2 {
+		t.Errorf("expected 2 unused keys, got %d.", len(metadata.Unused))
+	}
+}
+
+func TestDecoder_CaseSensitiveKeys_WithTagsAllMatches(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"bar": "hello",
+		"foo": "there",
+	}
+
+	var result Tagged
+	var metadata Metadata
+	config := &DecoderConfig{
+		CaseSensitiveKeys: true,
+		Metadata:          &metadata,
+		Result:            &result,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = decoder.Decode(input)
+	if err != nil {
+		t.Fatalf("got an err: %s", err)
+	}
+
+	if len(metadata.Unused) != 0 {
+		t.Errorf("expected 0 unused keys, got %d.", len(metadata.Unused))
+	}
+}
+
 func TestDecoder_ErrorUnused(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This pull request proposes adding a new configuration option: CaseSensitiveKeys.  If true, this would only allow for exact matches on struct Field/Tag names, whereas if false it would use the current behavior of doing Unicode code-folding on the key maps.

Example use case: The Experience API standard (xAPI, detailed here: https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#lrs-requirements ), which is defined on top of JSON, requires that "The LRS MUST reject Statements...where the case of a key does not match the case specified in this specification."  Someone bringing in the JSON data and wanting to use mapstructure to copy it into appropriately defined structs has to be sure that the "id" key is "id" and not "ID" in order to validate within the specification.

Good test coverage included in pull request.

There's also a tiny performance perk by not having to iterate the map! :)