### PR TITLE
Support json.Number decoding to uint

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -359,6 +359,7 @@ func (d *Decoder) decodeInt(name string, data interface{}, val reflect.Value) er
 func (d *Decoder) decodeUint(name string, data interface{}, val reflect.Value) error {
 	dataVal := reflect.ValueOf(data)
 	dataKind := getKind(dataVal)
+	dataType := dataVal.Type()
 
 	switch {
 	case dataKind == reflect.Int:
@@ -390,6 +391,18 @@ func (d *Decoder) decodeUint(name string, data interface{}, val reflect.Value) e
 		} else {
 			return fmt.Errorf("cannot parse '%s' as uint: %s", name, err)
 		}
+	case dataType.PkgPath() == "encoding/json" && dataType.Name() == "Number":
+		jn := data.(json.Number)
+		i, err := jn.Int64()
+		if err != nil {
+			return fmt.Errorf(
+				"error decoding json.Number into %s: %s", name, err)
+		}
+		if i < 0 && !d.config.WeaklyTypedInput {
+			return fmt.Errorf("cannot parse '%s', %d overflows uint",
+				name, i)
+		}
+		val.SetUint(uint64(i))
 	default:
 		return fmt.Errorf(
 			"'%s' expected type '%s', got unconvertible type '%s'",

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -19,6 +19,7 @@ type Basic struct {
 	vsilent     bool
 	Vdata       interface{}
 	VjsonInt    int
+	VjsonUint   uint
 	VjsonFloat  float64
 	VjsonNumber json.Number
 }
@@ -134,6 +135,7 @@ func TestBasicTypes(t *testing.T) {
 		"vsilent":     true,
 		"vdata":       42,
 		"vjsonInt":    json.Number("1234"),
+		"vjsonUint":   json.Number("1234"),
 		"vjsonFloat":  json.Number("1234.5"),
 		"vjsonNumber": json.Number("1234.5"),
 	}
@@ -179,6 +181,10 @@ func TestBasicTypes(t *testing.T) {
 
 	if result.VjsonInt != 1234 {
 		t.Errorf("vjsonint value should be 1234: %#v", result.VjsonInt)
+	}
+
+	if result.VjsonUint != 1234 {
+		t.Errorf("vjsonuint value should be 1234: %#v", result.VjsonUint)
 	}
 
 	if result.VjsonFloat != 1234.5 {


### PR DESCRIPTION
Extending pull request #51 to support `uint` in addition to the `int` and `float` types when decoding from an unmarshalled `json.Number`.