### PR TITLE
Add support string to byte slice

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -602,7 +602,8 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 						val.Set(reflect.MakeSlice(sliceType, 0, 0))
 						return nil
 					}
-
+				case dataValKind == reflect.String && valElemType.Kind() == reflect.Uint8:
+					return d.decodeSlice(name, []byte(dataVal.String()), val)
 				// All other types we try to convert to the slice type
 				// and "lift" it into it. i.e. a string becomes a string slice.
 				default:
@@ -610,7 +611,6 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 					return d.decodeSlice(name, []interface{}{data}, val)
 				}
 			}
-
 			return fmt.Errorf(
 				"'%s': source data must be an array or slice, got %s", name, dataValKind)
 

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -112,6 +112,7 @@ type TypeConversionResult struct {
 	FloatToBool        bool
 	FloatToString      string
 	SliceUint8ToString string
+	StringToSliceUint8 []byte
 	StringToInt        int
 	StringToUint       uint
 	StringToBool       bool
@@ -582,6 +583,7 @@ func TestDecode_TypeConversion(t *testing.T) {
 		"FloatToBool":        42.42,
 		"FloatToString":      42.42,
 		"SliceUint8ToString": []uint8("foo"),
+		"StringToSliceUint8": "foo",
 		"StringToInt":        "42",
 		"StringToUint":       "42",
 		"StringToBool":       "1",
@@ -622,6 +624,7 @@ func TestDecode_TypeConversion(t *testing.T) {
 		FloatToBool:        true,
 		FloatToString:      "42.42",
 		SliceUint8ToString: "foo",
+		StringToSliceUint8: []byte("foo"),
 		StringToInt:        42,
 		StringToUint:       42,
 		StringToBool:       true,


### PR DESCRIPTION
In weakly mode,`[]byte` can be converted to `string`,but `string` to `[]byte` will be failed. This pull request adds support for  `string`  to `[]byte` conversion.