### PR TITLE
README: add godoc badge at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mapstructure
+# mapstructure [![Godoc](https://godoc.org/github.com/mitchell/mapstructure?status.svg)](https://godoc.org/github.com/mitchell/mapstructure)
 
 mapstructure is a Go library for decoding generic map values to structures
 and vice versa, while providing helpful error handling.


### PR DESCRIPTION
Put the GoDoc badge right at the top, next to the first
heading so that it is visible and easy to visit.


#### Before
<img width="385" alt="screen shot 2017-08-30 at 4 46 58 pm" src="https://user-images.githubusercontent.com/4898263/29898417-e721cad6-8da2-11e7-8299-ab8cb876d807.png">

#### After
<img width="475" alt="screen shot 2017-08-30 at 4 46 47 pm" src="https://user-images.githubusercontent.com/4898263/29898422-ec7883da-8da2-11e7-9314-0bf2e8a21a22.png">