### PR TITLE
Improve decoding of interface{} fields

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -256,6 +256,9 @@ func (d *Decoder) decode(name string, data interface{}, val reflect.Value) error
 // This decodes a basic type (bool, int, string, etc.) and sets the
 // value to "data" of that type.
 func (d *Decoder) decodeBasic(name string, data interface{}, val reflect.Value) error {
+	if val.IsValid() && val.Elem().IsValid() {
+		return d.decode(name, data, val.Elem())
+	}
 	dataVal := reflect.ValueOf(data)
 	if !dataVal.IsValid() {
 		dataVal = reflect.Zero(val.Type())
@@ -557,16 +560,22 @@ func (d *Decoder) decodePtr(name string, data interface{}, val reflect.Value) er
 	valType := val.Type()
 	valElemType := valType.Elem()
 
-	realVal := val
-	if realVal.IsNil() || d.config.ZeroFields {
-		realVal = reflect.New(valElemType)
-	}
+	if val.CanSet() {
+		realVal := val
+		if realVal.IsNil() || d.config.ZeroFields {
+			realVal = reflect.New(valElemType)
+		}
 
-	if err := d.decode(name, data, reflect.Indirect(realVal)); err != nil {
-		return err
-	}
+		if err := d.decode(name, data, reflect.Indirect(realVal)); err != nil {
+			return err
+		}
 
-	val.Set(realVal)
+		val.Set(realVal)
+	} else {
+		if err := d.decode(name, data, reflect.Indirect(val)); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -227,6 +227,32 @@ func TestBasic_Merge(t *testing.T) {
 	}
 }
 
+// Test for issue #46.
+func TestBasic_Struct(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"vdata": map[string]interface{}{
+			"vstring": "foo",
+		},
+	}
+
+	var result, inner Basic
+	result.Vdata = &inner
+	err := Decode(input, &result)
+	if err != nil {
+		t.Fatalf("got an err: %s", err)
+	}
+	expected := Basic{
+		Vdata: &Basic{
+			Vstring: "foo",
+		},
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
 func TestDecode_BasicSquash(t *testing.T) {
 	t.Parallel()
 
@@ -869,6 +895,56 @@ func TestNestedTypePointer(t *testing.T) {
 
 	if result.Vbar.Vextra != "" {
 		t.Errorf("vextra value should be empty: %#v", result.Vbar.Vextra)
+	}
+}
+
+// Test for issue #46.
+func TestNestedTypeInterface(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"vfoo": "foo",
+		"vbar": &map[string]interface{}{
+			"vstring": "foo",
+			"vint":    42,
+			"vbool":   true,
+
+			"vdata": map[string]interface{}{
+				"vstring": "bar",
+			},
+		},
+	}
+
+	var result NestedPointer
+	result.Vbar = new(Basic)
+	result.Vbar.Vdata = new(Basic)
+	err := Decode(input, &result)
+	if err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+
+	if result.Vfoo != "foo" {
+		t.Errorf("vfoo value should be 'foo': %#v", result.Vfoo)
+	}
+
+	if result.Vbar.Vstring != "foo" {
+		t.Errorf("vstring value should be 'foo': %#v", result.Vbar.Vstring)
+	}
+
+	if result.Vbar.Vint != 42 {
+		t.Errorf("vint value should be 42: %#v", result.Vbar.Vint)
+	}
+
+	if result.Vbar.Vbool != true {
+		t.Errorf("vbool value should be true: %#v", result.Vbar.Vbool)
+	}
+
+	if result.Vbar.Vextra != "" {
+		t.Errorf("vextra value should be empty: %#v", result.Vbar.Vextra)
+	}
+
+	if result.Vbar.Vdata.(*Basic).Vstring != "bar" {
+		t.Errorf("vstring value should be 'bar': %#v", result.Vbar.Vdata.(*Basic).Vstring)
 	}
 }
 


### PR DESCRIPTION
A field of type interface{} pointing to an existing value should respect
the value type and fill in the pointed object instead of reassigning the
field with a map.

Thanks to @EaseWay for the original fix:

https://github.com/easeway/mapstructure/commit/3f04f074b18a58796031f043c5529147fac2c707

This commit updates EaseWay's fix and adds an additional test
(TestNestedTypeInterface). This test fails on 3f04f07 but now succeeds
due to additional improvements made since the fix was submitted.

Fixes issue #46.