### PR TITLE
feature: collecting unused fields using lostfound tag

### DIFF
--- a/mapstructure_examples_test.go
+++ b/mapstructure_examples_test.go
@@ -201,3 +201,33 @@ func ExampleDecode_embeddedStruct() {
 	// Output:
 	// Mitchell Hashimoto, San Francisco
 }
+
+func ExampleDecode_lostFound() {
+	// Catching unknown (unused) fields is supported through the lostfound
+	// tag. As shon below, even if we don't support the "person_location"
+	// field, we can still obtain it by dumping all unknown fields into the
+	// "Extra" field. This works recursively, and is helpful when decoding
+	// from a remote API which has a set of standard fields, and a set of
+	// fields which are not known beforehand.
+	type Person struct {
+		Name  string                 `mapstructure:"person_name"`
+		Age   int                    `mapstructure:"person_age"`
+		Extra map[string]interface{} `mapstructure:",lostfound"`
+	}
+
+	input := map[string]interface{}{
+		"person_name":     "Mitchell",
+		"person_age":      91,
+		"person_location": "San Francisco",
+	}
+
+	var result Person
+	err := Decode(input, &result)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s, age %d, %s", result.Name, result.Age, result.Extra["person_location"])
+	// Output:
+	// Mitchell, age 91, San Francisco
+}


### PR DESCRIPTION
I am currently working on an auto-generated api package, and the API which I am using is quite heavy about including random keys in structures based on user input. As some of these are completely unknown, and because most of the generated struct types for this api package consist of quite a few inline/anonymous structs (and structs within those structs, etc), this change would easily allow you to capture all of the fields which you haven't explicitly defined.

One could potentially try and use the unused metadata to try and do this externally, but with deeply embedded/inlined structures, it would be very unclean.