### PR TITLE
Check for data type before trying to access its composants prevent a panic error in decodeSlice

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -590,32 +590,32 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 	valElemType := valType.Elem()
 	sliceType := reflect.SliceOf(valElemType)
 
-	valSlice := val
-	if valSlice.IsNil() || d.config.ZeroFields {
-		// Check input type
-		if dataValKind != reflect.Array && dataValKind != reflect.Slice {
-			if d.config.WeaklyTypedInput {
-				switch {
-				// Empty maps turn into empty slices
-				case dataValKind == reflect.Map:
-					if dataVal.Len() == 0 {
-						val.Set(reflect.MakeSlice(sliceType, 0, 0))
-						return nil
-					}
-
-				// All other types we try to convert to the slice type
-				// and "lift" it into it. i.e. a string becomes a string slice.
-				default:
-					// Just re-try this function with data as a slice.
-					return d.decodeSlice(name, []interface{}{data}, val)
+	// Check input type
+	if dataValKind != reflect.Array && dataValKind != reflect.Slice {
+		if d.config.WeaklyTypedInput {
+			switch {
+			// Empty maps turn into empty slices
+			case dataValKind == reflect.Map:
+				if dataVal.Len() == 0 {
+					val.Set(reflect.MakeSlice(sliceType, 0, 0))
+					return nil
 				}
+
+			// All other types we try to convert to the slice type
+			// and "lift" it into it. i.e. a string becomes a string slice.
+			default:
+				// Just re-try this function with data as a slice.
+				return d.decodeSlice(name, []interface{}{data}, val)
 			}
-
-			return fmt.Errorf(
-				"'%s': source data must be an array or slice, got %s", name, dataValKind)
-
 		}
 
+		return fmt.Errorf(
+			"'%s': source data must be an array or slice, got %s", name, dataValKind)
+
+	}
+
+	valSlice := val
+	if valSlice.IsNil() || d.config.ZeroFields {
 		// Make a new slice to hold our result, same size as the original data.
 		valSlice = reflect.MakeSlice(sliceType, dataVal.Len(), dataVal.Len())
 	}

--- a/mapstructure_bugs_test.go
+++ b/mapstructure_bugs_test.go
@@ -258,3 +258,26 @@ func TestDecodeSliceToEmptySliceWOZeroing(t *testing.T) {
 		}
 	}
 }
+
+// #103 Check for data type before trying to access its composants prevent a panic error
+// in decodeSlice
+func TestDecodeBadDataTypeInSlice(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("got a panic")
+		}
+	}()
+
+	input := map[string]interface{}{
+		"Toto": "titi",
+	}
+	result := []struct {
+		Toto string
+	}{}
+
+	if err := Decode(input, &result); err == nil {
+		t.Error("An error was expected, got nil")
+	}
+}


### PR DESCRIPTION
If you tried to decode a map[string]struct into an initiliazed []struct with zeroField set to False, it would `panic: reflect: call of reflect.Value.Index on map Value` as the data type check wouldn't be done.

I just moved the data type check before checking for a nil slice or zeroField flag.