### PR TITLE
Provide more deccode context to the hooks

### DIFF
--- a/decode_hooks_test.go
+++ b/decode_hooks_test.go
@@ -25,7 +25,7 @@ func TestComposeDecodeHookFunc(t *testing.T) {
 	f := ComposeDecodeHookFunc(f1, f2)
 
 	result, err := DecodeHookExec(
-		f, reflect.TypeOf(""), reflect.TypeOf([]byte("")), "")
+		f, reflect.TypeOf(""), reflect.TypeOf([]byte("")), "", &DecodeContext{})
 	if err != nil {
 		t.Fatalf("bad: %s", err)
 	}
@@ -46,7 +46,7 @@ func TestComposeDecodeHookFunc_err(t *testing.T) {
 	f := ComposeDecodeHookFunc(f1, f2)
 
 	_, err := DecodeHookExec(
-		f, reflect.TypeOf(""), reflect.TypeOf([]byte("")), 42)
+		f, reflect.TypeOf(""), reflect.TypeOf([]byte("")), 42, &DecodeContext{})
 	if err.Error() != "foo" {
 		t.Fatalf("bad: %s", err)
 	}
@@ -73,7 +73,7 @@ func TestComposeDecodeHookFunc_kinds(t *testing.T) {
 	f := ComposeDecodeHookFunc(f1, f2)
 
 	_, err := DecodeHookExec(
-		f, reflect.TypeOf(""), reflect.TypeOf([]byte("")), "")
+		f, reflect.TypeOf(""), reflect.TypeOf([]byte("")), "", &DecodeContext{})
 	if err != nil {
 		t.Fatalf("bad: %s", err)
 	}
@@ -112,7 +112,7 @@ func TestStringToSliceHookFunc(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		actual, err := DecodeHookExec(f, tc.f, tc.t, tc.data)
+		actual, err := DecodeHookExec(f, tc.f, tc.t, tc.data, &DecodeContext{})
 		if tc.err != (err != nil) {
 			t.Fatalf("case %d: expected err %#v", i, tc.err)
 		}
@@ -141,7 +141,7 @@ func TestStringToTimeDurationHookFunc(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		actual, err := DecodeHookExec(f, tc.f, tc.t, tc.data)
+		actual, err := DecodeHookExec(f, tc.f, tc.t, tc.data, &DecodeContext{})
 		if tc.err != (err != nil) {
 			t.Fatalf("case %d: expected err %#v", i, tc.err)
 		}
@@ -171,7 +171,7 @@ func TestStringToTimeHookFunc(t *testing.T) {
 
 	for i, tc := range cases {
 		f := StringToTimeHookFunc(tc.layout)
-		actual, err := DecodeHookExec(f, tc.f, tc.t, tc.data)
+		actual, err := DecodeHookExec(f, tc.f, tc.t, tc.data, &DecodeContext{})
 		if tc.err != (err != nil) {
 			t.Fatalf("case %d: expected err %#v", i, tc.err)
 		}
@@ -246,7 +246,7 @@ func TestWeaklyTypedHook(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		actual, err := DecodeHookExec(f, tc.f, tc.t, tc.data)
+		actual, err := DecodeHookExec(f, tc.f, tc.t, tc.data, &DecodeContext{})
 		if tc.err != (err != nil) {
 			t.Fatalf("case %d: expected err %#v", i, tc.err)
 		}


### PR DESCRIPTION
When decoding into a generic map (or a struct that contains a generic map) knowing the source's type information isn't enough information to do type conversions in a hook.

Adding the `name` improves this, as it makes it possible to create a "type converter registry".

Adding a new func type for this is unfortunate, but that is to preserver backwards compability.

```bash
benchmark              old ns/op     new ns/op     delta
Benchmark_Decode-4     6991          7183          +2.75%

benchmark              old allocs     new allocs     delta
Benchmark_Decode-4     51             54             +5.88%

benchmark              old bytes     new bytes     delta
Benchmark_Decode-4     1992          2088          +4.82%
```

Fixes #122