### PR TITLE
A map of len > 0 will now be converted to slice if a slice result is …

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -762,6 +762,9 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 						val.Set(reflect.MakeSlice(sliceType, 0, 0))
 						return nil
 					}
+					// Create slice of maps of other sizes
+					return d.decodeSlice(name, []interface{}{data}, val)
+
 				case dataValKind == reflect.String && valElemType.Kind() == reflect.Uint8:
 					return d.decodeSlice(name, []byte(dataVal.String()), val)
 				// All other types we try to convert to the slice type

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -1139,6 +1139,37 @@ func TestSliceOfStruct(t *testing.T) {
 	}
 }
 
+func TestSliceCornerCases(t *testing.T) {
+	t.Parallel()
+
+	// Input with a map with zero values
+	input := map[string]interface{}{}
+	var resultWeak []Basic
+
+	err := WeakDecode(input, &resultWeak)
+	if err != nil {
+		t.Fatalf("got unexpected error: %s", err)
+	}
+
+	if len(resultWeak) != 0 {
+		t.Errorf("length should be 0")
+	}
+	// Input with more values
+	input = map[string]interface{}{
+		"Vstring": "foo",
+	}
+
+	resultWeak = nil
+	err = WeakDecode(input, &resultWeak)
+	if err != nil {
+		t.Fatalf("got unexpected error: %s", err)
+	}
+
+	if resultWeak[0].Vstring != "foo" {
+		t.Errorf("value does not match")
+	}
+}
+
 func TestSliceToMap(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Correct me if i am wrong, but as far as i can see a map with other length than 0 will skip the default case and in the DecodeSlice func. Also added tests for these corner cases