### PR TITLE
Check input for nil before and after decode hook.

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -257,6 +257,18 @@ func (d *Decoder) decode(name string, input interface{}, outVal reflect.Value) e
 		if err != nil {
 			return fmt.Errorf("error decoding '%s': %s", name, err)
 		}
+		if input == nil {
+			// If the data is nil, then we don't set anything, unless ZeroFields is set
+			// to true.
+			if d.config.ZeroFields {
+				outVal.Set(reflect.Zero(outVal.Type()))
+
+				if d.config.Metadata != nil && name != "" {
+					d.config.Metadata.Keys = append(d.config.Metadata.Keys, name)
+				}
+			}
+			return nil
+		}
 	}
 
 	var err error

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -83,6 +83,10 @@ type NilInterface struct {
 	W io.Writer
 }
 
+type NilPointer struct {
+	Value *string
+}
+
 type Slice struct {
 	Vfoo string
 	Vbar []string
@@ -624,6 +628,43 @@ func TestDecode_NilInterfaceHook(t *testing.T) {
 
 	if result.W != nil {
 		t.Errorf("W should be nil: %#v", result.W)
+	}
+}
+
+func TestDecode_NilPointerHook(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"value": "",
+	}
+
+	decodeHook := func(f, t reflect.Type, v interface{}) (interface{}, error) {
+		if typed, ok := v.(string); ok {
+			if typed == "" {
+				return nil, nil
+			}
+		}
+		return v, nil
+	}
+
+	var result NilPointer
+	config := &DecoderConfig{
+		DecodeHook: decodeHook,
+		Result:     &result,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = decoder.Decode(input)
+	if err != nil {
+		t.Fatalf("got an err: %s", err)
+	}
+
+	if result.Value != nil {
+		t.Errorf("W should be nil: %#v", result.Value)
 	}
 }
 


### PR DESCRIPTION
If input data is nil before decoding, we bail out early, but if decoding
a non-nil value returns a nil value, we continue with the decode method
and return a zero value. As described in #97, this makes it impossible
to return a nil value from a decode hook. This patch checks for nil
inputs before and after decoding.

[Fixes #97]