### PR TITLE
Struct to struct decoding + bug fixes

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -805,6 +805,11 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 
 		}
 
+		// If the input value is empty, then don't allocate since non-nil != nil
+		if dataVal.Len() == 0 {
+			return nil
+		}
+
 		// Make a new slice to hold our result, same size as the original data.
 		valSlice = reflect.MakeSlice(sliceType, dataVal.Len(), dataVal.Len())
 	}

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -316,7 +316,7 @@ func (d *Decoder) decodeBasic(name string, data interface{}, val reflect.Value) 
 	if val.IsValid() && val.Elem().IsValid() {
 		return d.decode(name, data, val.Elem())
 	}
-	dataVal := reflect.ValueOf(data)
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
 	if !dataVal.IsValid() {
 		dataVal = reflect.Zero(val.Type())
 	}
@@ -333,7 +333,7 @@ func (d *Decoder) decodeBasic(name string, data interface{}, val reflect.Value) 
 }
 
 func (d *Decoder) decodeString(name string, data interface{}, val reflect.Value) error {
-	dataVal := reflect.ValueOf(data)
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
 	dataKind := getKind(dataVal)
 
 	converted := true
@@ -385,7 +385,7 @@ func (d *Decoder) decodeString(name string, data interface{}, val reflect.Value)
 }
 
 func (d *Decoder) decodeInt(name string, data interface{}, val reflect.Value) error {
-	dataVal := reflect.ValueOf(data)
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
 	dataKind := getKind(dataVal)
 	dataType := dataVal.Type()
 
@@ -427,7 +427,7 @@ func (d *Decoder) decodeInt(name string, data interface{}, val reflect.Value) er
 }
 
 func (d *Decoder) decodeUint(name string, data interface{}, val reflect.Value) error {
-	dataVal := reflect.ValueOf(data)
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
 	dataKind := getKind(dataVal)
 
 	switch {
@@ -470,7 +470,7 @@ func (d *Decoder) decodeUint(name string, data interface{}, val reflect.Value) e
 }
 
 func (d *Decoder) decodeBool(name string, data interface{}, val reflect.Value) error {
-	dataVal := reflect.ValueOf(data)
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
 	dataKind := getKind(dataVal)
 
 	switch {
@@ -501,7 +501,7 @@ func (d *Decoder) decodeBool(name string, data interface{}, val reflect.Value) e
 }
 
 func (d *Decoder) decodeFloat(name string, data interface{}, val reflect.Value) error {
-	dataVal := reflect.ValueOf(data)
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
 	dataKind := getKind(dataVal)
 	dataType := dataVal.Type()
 

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -605,6 +605,20 @@ func (d *Decoder) decodeMapFromMap(name string, dataVal reflect.Value, val refle
 	// Accumulate errors
 	errors := make([]string, 0)
 
+	// If the input data is empty, then we just match what the input data is.
+	if dataVal.Len() == 0 {
+		if dataVal.IsNil() {
+			if !val.IsNil() {
+				val.Set(dataVal)
+			}
+		} else {
+			// Set to empty allocated value
+			val.Set(valMap)
+		}
+
+		return nil
+	}
+
 	for _, k := range dataVal.MapKeys() {
 		fieldName := fmt.Sprintf("%s[%s]", name, k)
 

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -106,6 +106,10 @@ type SliceOfStruct struct {
 	Value []Basic
 }
 
+type SlicePointer struct {
+	Vbar *[]string
+}
+
 type Array struct {
 	Vfoo string
 	Vbar [2]string
@@ -1432,6 +1436,22 @@ func TestDecodeTable(t *testing.T) {
 				Vfloat:  4.56,
 				Vdata:   []byte("data"),
 			},
+			false,
+		},
+		{
+			"slice non-pointer to pointer",
+			&Slice{},
+			&SlicePointer{},
+			&SlicePointer{},
+			false,
+		},
+		{
+			"slice non-pointer to pointer, zero field",
+			&Slice{},
+			&SlicePointer{
+				Vbar: &[]string{"yo"},
+			},
+			&SlicePointer{},
 			false,
 		},
 

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -102,6 +102,11 @@ type Slice struct {
 	Vbar []string
 }
 
+type SliceOfAlias struct {
+	Vfoo string
+	Vbar SliceAlias
+}
+
 type SliceOfStruct struct {
 	Value []Basic
 }
@@ -1452,6 +1457,13 @@ func TestDecodeTable(t *testing.T) {
 				Vbar: &[]string{"yo"},
 			},
 			&SlicePointer{},
+			false,
+		},
+		{
+			"slice to slice alias",
+			&Slice{},
+			&SliceOfAlias{},
+			&SliceOfAlias{},
 			false,
 		},
 

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -1316,8 +1316,11 @@ func TestArrayToMap(t *testing.T) {
 func TestDecodeTable(t *testing.T) {
 	t.Parallel()
 
+	// We need to make new types so that we don't get the short-circuit
+	// copy functionality. We want to test the deep copying functionality.
 	type BasicCopy Basic
 	type NestedPointerCopy NestedPointer
+	type MapCopy Map
 
 	tests := []struct {
 		name    string
@@ -1464,6 +1467,20 @@ func TestDecodeTable(t *testing.T) {
 			&Slice{},
 			&SliceOfAlias{},
 			&SliceOfAlias{},
+			false,
+		},
+		{
+			"nil map to map",
+			&Map{},
+			&MapCopy{},
+			&MapCopy{},
+			false,
+		},
+		{
+			"nil map to non-empty map",
+			&Map{},
+			&MapCopy{Vother: map[string]string{"foo": "bar"}},
+			&MapCopy{},
 			false,
 		},
 

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -23,6 +23,20 @@ type Basic struct {
 	VjsonNumber json.Number
 }
 
+type BasicPointer struct {
+	Vstring     *string
+	Vint        *int
+	Vuint       *uint
+	Vbool       *bool
+	Vfloat      *float64
+	Vextra      *string
+	vsilent     *bool
+	Vdata       *interface{}
+	VjsonInt    *int
+	VjsonFloat  *float64
+	VjsonNumber *json.Number
+}
+
 type BasicSquash struct {
 	Test Basic `mapstructure:",squash"`
 }
@@ -1399,6 +1413,27 @@ func TestDecodeTable(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"basic pointer to non-pointer",
+			&BasicPointer{
+				Vstring: stringPtr("vstring"),
+				Vint:    intPtr(2),
+				Vuint:   uintPtr(3),
+				Vbool:   boolPtr(true),
+				Vfloat:  floatPtr(4.56),
+				Vdata:   interfacePtr([]byte("data")),
+			},
+			&Basic{},
+			&Basic{
+				Vstring: "vstring",
+				Vint:    2,
+				Vuint:   3,
+				Vbool:   true,
+				Vfloat:  4.56,
+				Vdata:   []byte("data"),
+			},
+			false,
+		},
 
 		{
 			"slice input - should error",
@@ -1845,3 +1880,10 @@ func testArrayInput(t *testing.T, input map[string]interface{}, expected *Array)
 		}
 	}
 }
+
+func stringPtr(v string) *string              { return &v }
+func intPtr(v int) *int                       { return &v }
+func uintPtr(v uint) *uint                    { return &v }
+func boolPtr(v bool) *bool                    { return &v }
+func floatPtr(v float64) *float64             { return &v }
+func interfacePtr(v interface{}) *interface{} { return &v }

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -1290,8 +1290,11 @@ func TestArrayToMap(t *testing.T) {
 	}
 }
 
-func TestMapOutputForStructuredInputs(t *testing.T) {
+func TestDecodeTable(t *testing.T) {
 	t.Parallel()
+
+	type BasicCopy Basic
+	type NestedPointerCopy NestedPointer
 
 	tests := []struct {
 		name    string
@@ -1360,6 +1363,43 @@ func TestMapOutputForStructuredInputs(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"struct => struct",
+			&Basic{
+				Vstring: "vstring",
+				Vint:    2,
+				Vuint:   3,
+				Vbool:   true,
+				Vfloat:  4.56,
+				Vextra:  "vextra",
+				Vdata:   []byte("data"),
+				vsilent: true,
+			},
+			&BasicCopy{},
+			&BasicCopy{
+				Vstring: "vstring",
+				Vint:    2,
+				Vuint:   3,
+				Vbool:   true,
+				Vfloat:  4.56,
+				Vextra:  "vextra",
+				Vdata:   []byte("data"),
+			},
+			false,
+		},
+		{
+			"struct => struct with pointers",
+			&NestedPointer{
+				Vfoo: "hello",
+				Vbar: nil,
+			},
+			&NestedPointerCopy{},
+			&NestedPointerCopy{
+				Vfoo: "hello",
+			},
+			false,
+		},
+
 		{
 			"slice input - should error",
 			[]string{"foo", "bar"},


### PR DESCRIPTION
This introduces struct to struct decoding for decoding similar structs to other similar but differently typed structs. Along the way, this fixes some issues found that are more common with structs but could've affected non-struct decoding as well.

This is particularly useful for close-but-not-quite-the-same structs. Example:

```go
type A struct {
  Input string
}

type B struct {
  Input *string
}

// Can now convert like this:
mapstructure.Decode(&a, &b)
```

Additional bugs fixed:

  * Decoding a pointer like `*[]string` to a non-pointer `[]string` didn't work at all, this is fixed.
  * Decoding a non-pointer `[]string` to a pointer `*[]string` should keep the pointer `nil` if the source slice is nil.
  * Decoding a map to a map should set the destination map to nil if the source is nil (vs. empty).

**No tests were changed, only added,** so existing behavior should be preserved. 