### PR TITLE
add support for 'required' tag value

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -1323,9 +1323,19 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 		fieldName := field.Name
 
 		tagValue := field.Tag.Get(d.config.TagName)
-		tagValue = strings.SplitN(tagValue, ",", 2)[0]
-		if tagValue != "" {
-			fieldName = tagValue
+		tagFieldValue := strings.SplitN(tagValue, ",", 2)[0]
+		if tagFieldValue != "" {
+			fieldName = tagFieldValue
+		}
+
+		// If "required" is specified in the tag, we need make sure it is present.
+		required := false
+		tagParts := strings.Split(tagValue, ",")
+		for _, tag := range tagParts[1:] {
+			if tag == "required" {
+				required = true
+				break
+			}
 		}
 
 		rawMapKey := reflect.ValueOf(fieldName)
@@ -1348,6 +1358,10 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 			}
 
 			if !rawMapVal.IsValid() {
+				if required {
+					err := fmt.Errorf("'%s' is missing required key: %s", name, fieldName)
+					errors = appendErrors(errors, err)
+				}
 				// There was no matching key in the map for the value in
 				// the struct. Just ignore.
 				continue

--- a/mapstructure_examples_test.go
+++ b/mapstructure_examples_test.go
@@ -254,3 +254,27 @@ func ExampleDecode_omitempty() {
 	// Output:
 	// &map[Age:0 FirstName:Somebody]
 }
+
+func ExampleDecode_requiredField() {
+	// The required tag can indicate which fields in the struct are mandatory.
+	type Person struct {
+		FirstName string `mapstructure:",required"`
+		LastName  string `mapstructure:",required"`
+	}
+
+	input := map[string]interface{}{
+		"LastName": "Hashimoto",
+	}
+
+	var result Person
+	err := Decode(input, &result)
+	if err == nil {
+		panic("should have an error")
+	}
+
+	fmt.Println(err.Error())
+	// Output:
+	// 1 error(s) decoding:
+
+	// * '' is missing required key: FirstName
+}

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -173,6 +173,11 @@ type StructWithOmitEmpty struct {
 	OmitNestedField    *Nested                `mapstructure:"omittable-nested,omitempty"`
 }
 
+type Required struct {
+	RequiredBar string `mapstructure:"bar,required"`
+	Value       string `mapstructure:"foo"`
+}
+
 type TypeConversionResult struct {
 	IntToFloat         float32
 	IntToUint          uint
@@ -2428,6 +2433,20 @@ func TestDecode_mapToStruct(t *testing.T) {
 
 	if !reflect.DeepEqual(target, expected) {
 		t.Fatalf("bad: %#v", target)
+	}
+}
+
+func TestRequired(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"foo": "bar",
+	}
+
+	var result Required
+	err := Decode(input, &result)
+	if err == nil {
+		t.Fatal("unexpected success decoding required field was missing")
 	}
 }
 


### PR DESCRIPTION
Implementation for checking that required fields got filled in `map` -> `struct` decoding direction.

A basic test has been added as well.

```go
type Required struct {
	RequiredBar string `mapstructure:"bar,required"`
	Value       string `mapstructure:"foo"`
}
```

Fixes: #7 