### PR TITLE
Add a value hook func

### DIFF
--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -16,10 +16,11 @@ func typedDecodeHook(h DecodeHookFunc) DecodeHookFunc {
 	// Create variables here so we can reference them with the reflect pkg
 	var f1 DecodeHookFuncType
 	var f2 DecodeHookFuncKind
+	var f3 DecodeHookFuncValue
 
 	// Fill in the variables into this interface and the rest is done
 	// automatically using the reflect package.
-	potential := []interface{}{f1, f2}
+	potential := []interface{}{f1, f2, f3}
 
 	v := reflect.ValueOf(h)
 	vt := v.Type()
@@ -38,13 +39,15 @@ func typedDecodeHook(h DecodeHookFunc) DecodeHookFunc {
 // that took reflect.Kind instead of reflect.Type.
 func DecodeHookExec(
 	raw DecodeHookFunc,
-	from reflect.Type, to reflect.Type,
-	data interface{}) (interface{}, error) {
+	from reflect.Value, to reflect.Value) (interface{}, error) {
+
 	switch f := typedDecodeHook(raw).(type) {
 	case DecodeHookFuncType:
-		return f(from, to, data)
+		return f(from.Type(), to.Type(), from.Interface())
 	case DecodeHookFuncKind:
-		return f(from.Kind(), to.Kind(), data)
+		return f(from.Kind(), to.Kind(), from.Interface())
+	case DecodeHookFuncValue:
+		return f(from, to)
 	default:
 		return nil, errors.New("invalid decode hook signature")
 	}
@@ -56,22 +59,16 @@ func DecodeHookExec(
 // The composed funcs are called in order, with the result of the
 // previous transformation.
 func ComposeDecodeHookFunc(fs ...DecodeHookFunc) DecodeHookFunc {
-	return func(
-		f reflect.Type,
-		t reflect.Type,
-		data interface{}) (interface{}, error) {
+	return func(f reflect.Value, t reflect.Value) (interface{}, error) {
 		var err error
+		var data interface{}
+		newFrom := f
 		for _, f1 := range fs {
-			data, err = DecodeHookExec(f1, f, t, data)
+			data, err = DecodeHookExec(f1, newFrom, t)
 			if err != nil {
 				return nil, err
 			}
-
-			// Modify the from kind to be correct with the new data
-			f = nil
-			if val := reflect.ValueOf(data); val.IsValid() {
-				f = val.Type()
-			}
+			newFrom = reflect.ValueOf(data)
 		}
 
 		return data, nil
@@ -214,4 +211,22 @@ func WeaklyTypedHook(
 	}
 
 	return data, nil
+}
+
+func RecursiveStructToMapHookFunc() DecodeHookFunc {
+	return func(f reflect.Value, t reflect.Value) (interface{}, error) {
+		if f.Kind() != reflect.Struct {
+			return f.Interface(), nil
+		}
+
+		var i interface{} = struct{}{}
+		if t.Type() != reflect.TypeOf(&i).Elem() {
+			return f.Interface(), nil
+		}
+
+		m := make(map[string]interface{})
+		t.Set(reflect.ValueOf(m))
+
+		return f.Interface(), nil
+	}
 }

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -139,6 +139,10 @@ type DecodeHookFuncType func(reflect.Type, reflect.Type, interface{}) (interface
 // source and target types.
 type DecodeHookFuncKind func(reflect.Kind, reflect.Kind, interface{}) (interface{}, error)
 
+// DecodeHookFuncRaw is a DecodeHookFunc which has complete access to both the source and target
+// values.
+type DecodeHookFuncValue func(from reflect.Value, to reflect.Value) (interface{}, error)
+
 // DecoderConfig is the configuration that is used to create a new decoder
 // and allows customization of various aspects of decoding.
 type DecoderConfig struct {
@@ -368,9 +372,7 @@ func (d *Decoder) decode(name string, input interface{}, outVal reflect.Value) e
 	if d.config.DecodeHook != nil {
 		// We have a DecodeHook, so let's pre-process the input.
 		var err error
-		input, err = DecodeHookExec(
-			d.config.DecodeHook,
-			inputVal.Type(), outVal.Type(), input)
+		input, err = DecodeHookExec(d.config.DecodeHook, inputVal, outVal)
 		if err != nil {
 			return fmt.Errorf("error decoding '%s': %s", name, err)
 		}


### PR DESCRIPTION
## Overview
This commit adds a third hook func type which has access to the `reflect.Value` representations of both the `from` and the `to` objects. This gives all the same power of the existing hook functions (types, kinds, and data can all be retrieved from values), but with the additional benefit of being able to modify the `to` object.

## Change scope
This change is largely backwards compatible. The only change of the public API (other than adding a new hook type) is a change in the signature of `DecodeHookExec`. If that's a sticking point, I think there may be a way around it, but I haven't looked closely at it. 

## Motivation
Exposing the value of `to` opens up some really powerful patterns such as:
- Recursively decoding structs to maps (#166, #124). This PR includes a hook func that does this
- Setting the concrete struct type behind a destination interface before continuing to decode
- Setting defaults with tags (#111) or with a `Defaulter` interface
- Implement a hook for respecting `Unmarshaler` interfaces (#115)

Overall, I think if this is done right, it could really open a lot of possibility for more powerful hook funcs. The API works well, but I plan to play around with it a bit more to make sure it's as flexible as possible. I'm obviously open to any feedback