### PR TITLE
Fix an issues where pointers were causing a key to be recorded twice

### DIFF
--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -1939,6 +1939,11 @@ func TestDecodeMetadata(t *testing.T) {
 func TestMetadata(t *testing.T) {
 	t.Parallel()
 
+	type testResult struct {
+		Vfoo string
+		Vbar BasicPointer
+	}
+
 	input := map[string]interface{}{
 		"vfoo": "foo",
 		"vbar": map[string]interface{}{
@@ -1951,7 +1956,7 @@ func TestMetadata(t *testing.T) {
 	}
 
 	var md Metadata
-	var result Nested
+	var result testResult
 	config := &DecoderConfig{
 		Metadata: &md,
 		Result:   &result,


### PR DESCRIPTION
The issue I was running into was that for pointer fields in a struct the key was being recorded twice in the `Metadata.Keys` list. There are some cases where `decodePtr` will recurse into another call to `decode` which will add the field. However the outer `decode` call was unconditionally adding the field as well.

The updates in this PR change the behavior to only add the pointer fields name to the list of keys if no recursion was performed.