### PR TITLE
Update README.md : include a sed snippet to help with adding mapstructure tag to fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/map
 you can use the following snippets in which by using `sed`, `mapstructure` tag will be added to all struct fields in a go file which already have a `json` tag.
 
 ```bash
-sed -i.bak -e '/mapstructure/!{s/^\(.*`\)\(.*\)\(json:\)\(\".*\"\).*\(`\)$/\1\2\3\4 mapstructure:\4\5/p};' target.go
+sed -i.bak -e '/mapstructure/!{s/^\(.*`\)\(.*\)\(json:\)\(\".*\"\).*\(`\)$/\1\2\3\4 mapstructure:\4\5/g};' target.go
 ```
 
 The `Decode` function has examples associated with it there.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ $ go get github.com/mitchellh/mapstructure
 
 For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/mapstructure).
 
+you can use the following snippets in which by using `sed`, `mapstructure` tag will be added to all struct fields in a go file which already have a `json` tag.
+
+```bash
+sed -i.bak -e '/mapstructure/!{s/^\(.*`\)\(.*\)\(json:\)\(\".*\"\).*\(`\)$/\1\2\3\4 mapstructure:\4\5/p};' target.go
+```
+
 The `Decode` function has examples associated with it there.
 
 ## But Why?!


### PR DESCRIPTION
# Overview

This commit adds a single sed snippet to help with metaprogramming and adding `mapstructure` tags to structs which already have a JSON tag

# Change Scope

`README.md` file

# Motivation

Just like many others, I am a huge fan of @mitchellh libraries and I try to include `mapstructure` tag every time I create a struct. The issue is when working on large monorepos, sometimes I get exhausted and forget to include the tag as I am including JSON tag. Sometimes, such as when I am refactoring old code or working with protobufs, the structs do not have a `mapstructure` tag and it can be extremely tedious to search a repo of +15000 lines of code and add the tags manually. combination of this sed snippet and `find` should help with adding and modifying structs across all files in a repo very quickly.