### PR TITLE
Allow decoding embedded struct pointer in decodeMapFromStruct

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -894,6 +894,11 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal reflect.Value, val re
 			keyName = tagValue
 		}
 
+		// This is an embedded struct pointer, handle it as a embedded struct below
+		if v.Kind() == reflect.Ptr && reflect.Indirect(v).Kind() == reflect.Struct {
+			v = reflect.Indirect(v)
+		}
+
 		switch v.Kind() {
 		// this is an embedded struct, so handle it differently
 		case reflect.Struct:

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2322,6 +2322,11 @@ func TestDecode_StructTaggedWithOmitempty_KeepNonEmptyValues(t *testing.T) {
 	var emptySlice []interface{}
 	var emptyMap map[string]interface{}
 	var emptyNested *Nested
+	nestedMap := map[string]interface{}{}
+	err := Decode(input.OmitNestedField, &nestedMap)
+	if err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
 	expected := &map[string]interface{}{
 		"visible-string":   "",
 		"omittable-string": "string",
@@ -2334,7 +2339,7 @@ func TestDecode_StructTaggedWithOmitempty_KeepNonEmptyValues(t *testing.T) {
 		"visible-map":      emptyMap,
 		"omittable-map":    map[string]interface{}{"k": "v"},
 		"visible-nested":   emptyNested,
-		"omittable-nested": &Nested{},
+		"omittable-nested": nestedMap,
 	}
 
 	actual := &map[string]interface{}{}


### PR DESCRIPTION
This may address #156 , but it is not my use case, so I did not validated this case particularly.