### PR TITLE
Ensure that intermediate maps during struct to struct decoding are settable

### DIFF
--- a/mapstructure_bugs_test.go
+++ b/mapstructure_bugs_test.go
@@ -3,6 +3,7 @@ package mapstructure
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 // GH-1, GH-10, GH-96
@@ -473,5 +474,68 @@ func TestDecodeBadDataTypeInSlice(t *testing.T) {
 
 	if err := Decode(input, &result); err == nil {
 		t.Error("An error was expected, got nil")
+	}
+}
+
+// #202 Ensure that intermediate maps in the struct -> struct decode process are settable
+// and not just the elements within them.
+func TestDecodeIntermeidateMapsSettable(t *testing.T) {
+	type Timestamp struct {
+		Seconds int64
+		Nanos   int32
+	}
+
+	type TsWrapper struct {
+		Timestamp *Timestamp
+	}
+
+	type TimeWrapper struct {
+		Timestamp time.Time
+	}
+
+	input := TimeWrapper{
+		Timestamp: time.Unix(123456789, 987654),
+	}
+
+	expected := TsWrapper{
+		Timestamp: &Timestamp{
+			Seconds: 123456789,
+			Nanos:   987654,
+		},
+	}
+
+	timePtrType := reflect.TypeOf((*time.Time)(nil))
+	mapStrInfType := reflect.TypeOf((map[string]interface{})(nil))
+
+	var actual TsWrapper
+	decoder, err := NewDecoder(&DecoderConfig{
+		Result: &actual,
+		DecodeHook: func(from, to reflect.Type, data interface{}) (interface{}, error) {
+			if from == timePtrType && to == mapStrInfType {
+				ts := data.(*time.Time)
+				nanos := ts.UnixNano()
+
+				seconds := nanos / 1000000000
+				nanos = nanos % 1000000000
+
+				return &map[string]interface{}{
+					"Seconds": seconds,
+					"Nanos":   int32(nanos),
+				}, nil
+			}
+			return data, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("failed to create decoder: %v", err)
+	}
+
+	if err := decoder.Decode(&input); err != nil {
+		t.Fatalf("failed to decode input: %v", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected: %#[1]v (%[1]T), got: %#[2]v (%[2]T)", expected, actual)
 	}
 }


### PR DESCRIPTION
Fixes #202 