### PR TITLE
Ability to match field names in a case sensitive manner

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -14,7 +14,8 @@
 // When decoding to a struct, mapstructure will use the field name by
 // default to perform the mapping. For example, if a struct has a field
 // "Username" then mapstructure will look for a key in the source value
-// of "username" (case insensitive).
+// of "username". The case sensitivity is determined by the
+// DecoderConfig.CaseSensitive field .
 //
 //     type User struct {
 //         Username string
@@ -239,6 +240,10 @@ type DecoderConfig struct {
 	// The tag name that mapstructure reads for field names. This
 	// defaults to "mapstructure"
 	TagName string
+
+	// Whether to perform a case sensitive comparison between map keys and struct
+	// field names or not. Default false
+	CaseSensitive bool
 }
 
 // A Decoder takes a raw interface value and turns it into structured
@@ -1295,7 +1300,13 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 					continue
 				}
 
-				if strings.EqualFold(mK, fieldName) {
+				var matches bool
+				if d.config.CaseSensitive {
+					matches = mK == fieldName
+				} else {
+					matches = strings.EqualFold(mK, fieldName)
+				}
+				if matches {
 					rawMapKey = dataValKey
 					rawMapVal = dataVal.MapIndex(dataValKey)
 					break

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -242,7 +242,8 @@ type DecoderConfig struct {
 	TagName string
 
 	// Whether to perform a case sensitive comparison between map keys and struct
-	// field names or not. Default false
+	// field names or not. Note that the first letter of field names is always compared case
+	// insensitively i.e fooBar matches FooBar but doesn't match foobar or Foobar . Default false
 	CaseSensitive bool
 }
 
@@ -1302,7 +1303,7 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 
 				var matches bool
 				if d.config.CaseSensitive {
-					matches = mK == fieldName
+					matches = mK == fieldName || strings.Title(mK) == fieldName
 				} else {
 					matches = strings.EqualFold(mK, fieldName)
 				}

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -15,7 +15,7 @@
 // default to perform the mapping. For example, if a struct has a field
 // "Username" then mapstructure will look for a key in the source value
 // of "username". The case sensitivity is determined by the
-// DecoderConfig.CaseSensitive field .
+// combination of DecoderConfig.CaseSensitive and DecoderConfig.TitleCaseInsensitive fields .
 //
 //     type User struct {
 //         Username string
@@ -246,9 +246,15 @@ type DecoderConfig struct {
 	TagName string
 
 	// Whether to perform a case sensitive comparison between map keys and struct
-	// field names or not. Note that the first letter of field names is always compared case
-	// insensitively i.e fooBar matches FooBar but doesn't match foobar or Foobar . Default false
+	// field names or not. Default false
 	CaseSensitive bool
+
+	// Works in combination with CaseSensitive only: whether to compare the first
+	// letter of field names case insensitively or not in order to accommodate Golang
+	// exported fields
+	// i.e fooBar matches FooBar if the field name is title cased
+	// Default false
+	TitleCaseInsensitive bool
 }
 
 // A Decoder takes a raw interface value and turns it into structured
@@ -1328,7 +1334,7 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 
 				var matches bool
 				if d.config.CaseSensitive {
-					matches = mK == fieldName || strings.Title(mK) == fieldName
+					matches = mK == fieldName || (d.config.TitleCaseInsensitive && strings.Title(mK) == fieldName)
 				} else {
 					matches = strings.EqualFold(mK, fieldName)
 				}

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2450,6 +2450,94 @@ func TestDecode_mapToStruct(t *testing.T) {
 	}
 }
 
+func TestDecoder_CaseSensitive(t *testing.T) {
+	t.Parallel()
+
+	type Target struct {
+		NoMatch 	string
+		DoesMatch	string
+	}
+
+	input := map[string]interface{}{
+		"noMatch":	 "foo",
+		"DoesMatch": "bar",
+	}
+
+	var result Target
+	config := &DecoderConfig{
+		Result:      &result,
+		CaseSensitive: true,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = decoder.Decode(input)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if result.NoMatch != "" {
+		t.Errorf("NoMatch expected '', got '%s'", result.NoMatch)
+	}
+
+	if result.DoesMatch != input["DoesMatch"].(string) {
+		t.Errorf("DoesMatch expected '%s', got '%s'", input["DoesMatch"].(string), result.DoesMatch)
+	}
+}
+
+func TestDecoder_CaseSensitive_TitleCaseSensitive(t *testing.T) {
+	t.Parallel()
+
+	type Target struct {
+		FirstMatch 	string
+		SecondMatch	string
+		NoMatch		string
+	}
+
+	input := map[string]interface{}{
+		"firstMatch": 	"foo",
+		"SecondMatch": 	"bar",
+		"nomatch":		"baz",
+	}
+
+	var result Target
+	config := &DecoderConfig{
+		Result:      &result,
+		CaseSensitive: true,
+		TitleCaseInsensitive: true,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = decoder.Decode(input)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if result.NoMatch != "" {
+		t.Errorf("NoMatch expected '', got '%s'", result.NoMatch)
+	}
+
+	if result.FirstMatch != input["firstMatch"].(string) {
+		t.Errorf("FirstMatch expected '%s', got '%s'", input["FirstMatch"].(string), result.FirstMatch)
+	}
+
+	if result.SecondMatch != input["SecondMatch"].(string) {
+		t.Errorf("SecondMatch expected '%s', got '%s'", input["SecondMatch"].(string), result.SecondMatch)
+	}
+
+	if result.NoMatch != "" {
+		t.Errorf("NoMatch expected '', got '%s'", result.NoMatch)
+	}
+}
+
+
 func testSliceInput(t *testing.T, input map[string]interface{}, expected *Slice) {
 	var result Slice
 	err := Decode(input, &result)


### PR DESCRIPTION
Fixes #208 
I've added a new configuration option and the associated code to be able to match map keys to field names case sensitively.
However, the first letter of struct field names is still compared case insensitively, to allow for the Go convention of publicly exported member names.
