### PR TITLE
Replace fmt.Sprintf calls with string concatenation and strconv

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -785,7 +785,7 @@ func (d *Decoder) decodeMapFromSlice(name string, dataVal reflect.Value, val ref
 
 	for i := 0; i < dataVal.Len(); i++ {
 		err := d.decode(
-			fmt.Sprintf("%s[%d]", name, i),
+			name + "[" + strconv.Itoa(i) + "]",
 			dataVal.Index(i).Interface(), val)
 		if err != nil {
 			return err
@@ -818,7 +818,7 @@ func (d *Decoder) decodeMapFromMap(name string, dataVal reflect.Value, val refle
 	}
 
 	for _, k := range dataVal.MapKeys() {
-		fieldName := fmt.Sprintf("%s[%s]", name, k)
+		fieldName := name + "[" + k + "]"
 
 		// First decode the key into the proper type
 		currentKey := reflect.Indirect(reflect.New(valKeyType))
@@ -1062,7 +1062,7 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 		}
 		currentField := valSlice.Index(i)
 
-		fieldName := fmt.Sprintf("%s[%d]", name, i)
+		fieldName := name + "[" + strconv.Itoa(num) + "]"
 		if err := d.decode(fieldName, currentData, currentField); err != nil {
 			errors = appendErrors(errors, err)
 		}
@@ -1129,7 +1129,7 @@ func (d *Decoder) decodeArray(name string, data interface{}, val reflect.Value) 
 		currentData := dataVal.Index(i).Interface()
 		currentField := valArray.Index(i)
 
-		fieldName := fmt.Sprintf("%s[%d]", name, i)
+		fieldName := name + "[" + strconv.Itoa(i) + "]"
 		if err := d.decode(fieldName, currentData, currentField); err != nil {
 			errors = appendErrors(errors, err)
 		}
@@ -1326,7 +1326,7 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 		// If the name is empty string, then we're at the root, and we
 		// don't dot-join the fields.
 		if name != "" {
-			fieldName = fmt.Sprintf("%s.%s", name, fieldName)
+			fieldName = name + "." + fieldName
 		}
 
 		if err := d.decode(fieldName, rawMapVal.Interface(), fieldValue); err != nil {
@@ -1373,7 +1373,7 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 		for rawKey := range dataValKeysUnused {
 			key := rawKey.(string)
 			if name != "" {
-				key = fmt.Sprintf("%s.%s", name, key)
+				key = name + "." + key
 			}
 
 			d.config.Metadata.Unused = append(d.config.Metadata.Unused, key)


### PR DESCRIPTION
### Description
In a couple of the tight loops in mapstructure.go `fmt.Sprintf` is used to concatenate values, ex:
```go
fmt.Sprintf("%s[%d]", name, i)
```
This is actually slower and requires additional allocations compared to direct string concatenation and strconv:
```go
name + "[" + strconv.Itoa(i) + "]"
```

### Benchmark
```shell
$ go test -bench .
goos: darwin
goarch: amd64
BenchmarkDotPlus-12         	34628470	        29.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkDotSprintf-12      	 7306100	       155 ns/op	      64 B/op	       3 allocs/op
BenchmarkIndexPlus-12       	19705131	        57.9 ns/op	       4 B/op	       1 allocs/op
BenchmarkIndexSprintf-12    	 7302392	       170 ns/op	      40 B/op	       3 allocs/op
```

```go
package main_test

import (
    "fmt"
    "strconv"
    "testing"
)

var prefix = "someprefix"
var name = "somefield"
var num = 1234

func BenchmarkDotPlus(b *testing.B) {
    b.ReportAllocs()
    for n := 0; n < b.N; n++ {
        _ = prefix + "." + name
    }
}

func BenchmarkDotSprintf(b *testing.B) {
    b.ReportAllocs()
    for n := 0; n < b.N; n++ {
        _ = fmt.Sprintf("%s.%s", prefix, name)
    }
}

func BenchmarkIndexPlus(b *testing.B) {
    b.ReportAllocs()
    for n := 0; n < b.N; n++ {
        _ = name + "[" + strconv.Itoa(num) + "]"
    }
}

func BenchmarkIndexSprintf(b *testing.B) {
    b.ReportAllocs()
    for n := 0; n < b.N; n++ {
        _ = fmt.Sprintf("%s[%d]", name, num)
    }
}
```