### PR TITLE
decodeMapFromStruct: Only deref element if we're squashing the struct

### DIFF
--- a/mapstructure_bugs_test.go
+++ b/mapstructure_bugs_test.go
@@ -567,3 +567,37 @@ func TestDecode_weakEmptyStringToInt(t *testing.T) {
 		t.Errorf("expected \n%#v, got: \n%#v", expectedResultWeak, resultWeak)
 	}
 }
+
+// GH-228: Squash cause *time.Time set to zero
+func TestMapSquash(t *testing.T) {
+	type AA struct {
+		T *time.Time
+	}
+	type A struct {
+		AA
+	}
+
+	v := time.Now()
+	in := &AA{
+		T: &v,
+	}
+	out := &A{}
+	d, err := NewDecoder(&DecoderConfig{
+		Squash: true,
+		Result: out,
+	})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := d.Decode(in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// these failed
+	if !v.Equal(*out.T) {
+		t.Fatal("expected equal")
+	}
+	if out.T.IsZero() {
+		t.Fatal("expected false")
+	}
+}

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2390,26 +2390,7 @@ func TestDecode_StructTaggedWithOmitempty_KeepNonEmptyValues(t *testing.T) {
 		"visible-map":      emptyMap,
 		"omittable-map":    map[string]interface{}{"k": "v"},
 		"visible-nested":   emptyNested,
-		"omittable-nested": map[string]interface{}{
-			"Vbar": map[string]interface{}{
-				"Vbool":       false,
-				"Vdata":       interface{}(nil),
-				"Vextra":      "",
-				"Vfloat":      float64(0),
-				"Vint":        0,
-				"Vint16":      int16(0),
-				"Vint32":      int32(0),
-				"Vint64":      int64(0),
-				"Vint8":       int8(0),
-				"VjsonFloat":  float64(0),
-				"VjsonInt":    0,
-				"VjsonNumber": json.Number(""),
-				"VjsonUint":   uint(0),
-				"Vstring":     "",
-				"Vuint":       uint(0),
-			},
-			"Vfoo": "",
-		},
+		"omittable-nested": &Nested{},
 	}
 
 	actual := &map[string]interface{}{}


### PR DESCRIPTION
Fixes #231

This also reverts the test _change_ that was introduced in 231 back to
the original test. This retains the _new tests_ added in 231 to verify
the behavior of 231.

cc @dnephin 