### PR TITLE
Support custom name matchers

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -258,6 +258,10 @@ type DecoderConfig struct {
 	// The tag name that mapstructure reads for field names. This
 	// defaults to "mapstructure"
 	TagName string
+
+	// MatchName is the function used to match the map key to the struct
+	// field name or tag. Defaults to `strings.EqualFold`.
+	MatchName func(mapKey, fieldName string) bool
 }
 
 // A Decoder takes a raw interface value and turns it into structured
@@ -1340,7 +1344,7 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 					continue
 				}
 
-				if strings.EqualFold(mK, fieldName) {
+				if d.matchName(mK, fieldName) {
 					rawMapKey = dataValKey
 					rawMapVal = dataVal.MapIndex(dataValKey)
 					break
@@ -1426,6 +1430,13 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 	}
 
 	return nil
+}
+
+func (d *Decoder) matchName(mapKey, fieldName string) bool {
+	if d.config.MatchName != nil {
+		return d.config.MatchName(mapKey, fieldName)
+	}
+	return strings.EqualFold(mapKey, fieldName)
 }
 
 func isEmptyValue(v reflect.Value) bool {

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2431,6 +2431,49 @@ func TestDecode_mapToStruct(t *testing.T) {
 	}
 }
 
+func TestDecoder_MatchName(t *testing.T) {
+	t.Parallel()
+
+	type Target struct {
+		FirstMatch  string `mapstructure:"first_match"`
+		SecondMatch string
+		NoMatch     string `mapstructure:"no_match"`
+	}
+
+	input := map[string]interface{}{
+		"first_match": "foo",
+		"SecondMatch": "bar",
+		"NO_MATCH":    "baz",
+	}
+
+	expected := Target{
+		FirstMatch:  "foo",
+		SecondMatch: "bar",
+	}
+
+	var actual Target
+	config := &DecoderConfig{
+		Result: &actual,
+		MatchName: func(mapKey, fieldName string) bool {
+			return mapKey == fieldName
+		},
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = decoder.Decode(input)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Decode() expected: %#v, got: %#v", expected, actual)
+	}
+}
+
 func testSliceInput(t *testing.T, input map[string]interface{}, expected *Slice) {
 	var result Slice
 	err := Decode(input, &result)


### PR DESCRIPTION
Fixes #89 and #208 in a more dynamic way than https://github.com/mitchellh/mapstructure/pull/81, https://github.com/mitchellh/mapstructure/pull/176 or https://github.com/mitchellh/mapstructure/pull/207. Rather than just supporting a single use-case this also allows any other form of custom name matcher e.g. using https://github.com/iancoleman/strcase to automatically match to snake_case or kebab-case.

For example:

```go
type Target struct {
  FooBar string
}

var out Target

config := &DecoderConfig{
  Result: &out,
  MatchName: func(mapKey, fieldName string) bool {
    return strcase.ToCamel(mapKey) == fieldName
  },
}

decoder, _ := NewDecoder(config)

decoder.Decode(map[string]interface{}{
  "foo_bar": "baz",
})
```
Would result in `out` being:
```go
Target{
  FooBar: "baz",
}
```