### PR TITLE
Fix possible panic when using ComposeDecodeHookFunc() with no funcs

### DIFF
--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -63,6 +63,11 @@ func ComposeDecodeHookFunc(fs ...DecodeHookFunc) DecodeHookFunc {
 	return func(f reflect.Value, t reflect.Value) (interface{}, error) {
 		var err error
 		var data interface{}
+
+		if len(fs) == 0 {
+			data = f.Interface()
+		}
+
 		newFrom := f
 		for _, f1 := range fs {
 			data, err = DecodeHookExec(f1, newFrom, t)

--- a/decode_hooks_test.go
+++ b/decode_hooks_test.go
@@ -84,6 +84,38 @@ func TestComposeDecodeHookFunc_kinds(t *testing.T) {
 	}
 }
 
+func TestComposeDecodeHookFunc_safe_nofuncs(t *testing.T) {
+	f := ComposeDecodeHookFunc()
+	type myStruct2 struct {
+		MyInt int
+	}
+
+	type myStruct1 struct {
+		Blah map[string]myStruct2
+	}
+
+	src := &myStruct1{Blah: map[string]myStruct2{
+		"test": {
+			MyInt: 1,
+		},
+	}}
+
+	dst := &myStruct1{}
+	dConf := &DecoderConfig{
+		Result:      dst,
+		ErrorUnused: true,
+		DecodeHook:  f,
+	}
+	d, err := NewDecoder(dConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = d.Decode(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestStringToSliceHookFunc(t *testing.T) {
 	f := StringToSliceHookFunc(",")
 


### PR DESCRIPTION
On < v1.3.3, `ComposeDecodeHookFunc()` was safe to use with no args, but since decea915226622f93c74393f562948d16af8a118 (v1.4.1) it can cause a panic due to it accidentally replacing the `input` with an untyped `nil` after the `nil` check on L405 https://github.com/mitchellh/mapstructure/blob/4664f9ee512b4dfa71b501c4960d469c205b2cf1/mapstructure.go#L405

This PR restores the previous behaviour with minimal impact to allow easier upgrades