### PR TITLE
slice mapping bug fix

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -1096,6 +1096,8 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 	if valSlice.IsNil() || d.config.ZeroFields {
 		// Make a new slice to hold our result, same size as the original data.
 		valSlice = reflect.MakeSlice(sliceType, dataVal.Len(), dataVal.Len())
+	} else if valSlice.Len() > dataVal.Len() {
+		valSlice = valSlice.Slice(0, dataVal.Len())
 	}
 
 	// Accumulate any errors

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -138,6 +138,11 @@ type Slice struct {
 	Vbar []string
 }
 
+type SliceOfByte struct {
+	Vfoo string
+	Vbar []byte
+}
+
 type SliceOfAlias struct {
 	Vfoo string
 	Vbar SliceAlias
@@ -1652,6 +1657,34 @@ func TestSlice(t *testing.T) {
 
 	testSliceInput(t, inputStringSlice, outputStringSlice)
 	testSliceInput(t, inputStringSlicePointer, outputStringSlice)
+}
+
+func TestNotEmptyByteSlice(t *testing.T) {
+	t.Parallel()
+
+	inputByteSlice := map[string]interface{}{
+		"vfoo": "foo",
+		"vbar": []byte(`{"bar": "bar"}`),
+	}
+
+	result := SliceOfByte{
+		Vfoo: "another foo",
+		Vbar: []byte(`{"bar": "bar bar bar bar bar bar bar bar"}`),
+	}
+
+	err := Decode(inputByteSlice, &result)
+	if err != nil {
+		t.Fatalf("got unexpected error: %s", err)
+	}
+
+	expected := SliceOfByte{
+		Vfoo: "foo",
+		Vbar: []byte(`{"bar": "bar"}`),
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("bad: %#v", result)
+	}
 }
 
 func TestInvalidSlice(t *testing.T) {


### PR DESCRIPTION
```go
type Test struct {
	Attributes []byte `json:"attributes"`
}

type TestReq struct {
	Attributes []byte `json:"attributes"`
}

func TestMapping(t *testing.T) {
	req := TestReq{Attributes: []byte(`[{"data": "some data"}]`)}

	var test Test
	test.Attributes = []byte(`[{"a" : "1"}]`)

	err := mapstructure.Decode(req, &test)
	if err != nil {
		panic(err)
	}

	fmt.Println(string(test.Attributes))
	// result will be [{"data": "some data"}]
}

func TestMappingFail(t *testing.T) {
	req := TestReq{Attributes: []byte(`[{"data":"some data"}]`)}

	var test Test
	test.Attributes = []byte(`[{"a":"1111111111111111111111111111111111111111111111"}]`)

	err := mapstructure.Decode(req, &test)
	if err != nil {
		panic(err)
	}

	fmt.Println(string(test.Attributes))
	// result will be [{"data": "some data"}]11111111111111111111111111111111"}]
}

```