### PR TITLE
support emit any value

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -182,6 +182,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // DecodeHookFunc is the callback function that can be used for
@@ -958,6 +959,20 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal reflect.Value, val re
 				continue
 			}
 			keyName = tagValue
+		}
+
+		if v.Type() == reflect.TypeOf(time.Time{}) {
+			tagVals := strings.Split(tagValue, ",")
+			if len(tagVals) < 2 {
+				valMap.SetMapIndex(reflect.ValueOf(keyName), v)
+				continue
+			}
+			layout := "2006-01-02 15:04:05"
+			if len(tagVals) >= 3 {
+				layout = tagVals[2]
+			}
+			valMap.SetMapIndex(reflect.ValueOf(keyName), reflect.ValueOf(reflect.Indirect(v).Interface().(time.Time).Format(layout)))
+			continue
 		}
 
 		switch v.Kind() {

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -1483,6 +1483,10 @@ func isEmptyValue(v reflect.Value) bool {
 	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
 	}
+	// zero value for time
+	if reflect.Indirect(v).Type() == reflect.TypeOf(time.Time{}) {
+		return reflect.Indirect(v).Interface().(time.Time).IsZero()
+	}
 	return false
 }
 

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -118,6 +118,7 @@
 // the zero value. The zero value of all types is specified in the Go
 // specification.
 //
+
 // For example, the zero type of a numeric type is zero ("0"). If the struct
 // field value is zero and a numeric type, the field is empty, and it won't
 // be encoded into the destination type.
@@ -125,6 +126,21 @@
 //     type Source {
 //         Age int `mapstructure:",omitempty"`
 //     }
+//
+//
+// you also can use the ",omitvalue" suffix on your tag to omit that value if it equates to
+// the value you gave. it only support string, any other types will be convent to string.
+//
+// For example, .
+//
+//     type Source {
+//         Age int `mapstructure:",omitvalue:-1"`
+//     }{
+//		   Age : -1
+//		}
+//
+// field Age won't be encoded into the destination type
+//
 //
 // Unexported fields
 //
@@ -916,6 +932,10 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal reflect.Value, val re
 			}
 			// If "omitempty" is specified in the tag, it ignores empty values.
 			if strings.Index(tagValue[index+1:], "omitempty") != -1 && isEmptyValue(v) {
+				continue
+			}
+			// If "omitvalue" is specified in the tag, it ignores the gave value, only support string, other types vill be convent to string.
+			if strings.Index(tagValue[index+1:], "omitvalue") != -1 && tagValue[index+11:] == fmt.Sprint(v) {
 				continue
 			}
 

--- a/mapstructure_bugs_test.go
+++ b/mapstructure_bugs_test.go
@@ -504,15 +504,16 @@ func TestDecodeIntermediateMapsSettable(t *testing.T) {
 		},
 	}
 
-	timePtrType := reflect.TypeOf((*time.Time)(nil))
-	mapStrInfType := reflect.TypeOf((map[string]interface{})(nil))
+	timePtrType := reflect.TypeOf((time.Time{}))
+	// mapStrInfType := reflect.TypeOf((map[string]interface{})(nil))
 
 	var actual TsWrapper
 	decoder, err := NewDecoder(&DecoderConfig{
 		Result: &actual,
 		DecodeHook: func(from, to reflect.Type, data interface{}) (interface{}, error) {
-			if from == timePtrType && to == mapStrInfType {
-				ts := data.(*time.Time)
+			// if from == timePtrType && to == mapStrInfType {
+			if from == timePtrType {
+				ts := data.(time.Time)
 				nanos := ts.UnixNano()
 
 				seconds := nanos / 1000000000

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
 type Basic struct {
@@ -1689,6 +1690,8 @@ func TestDecodeTable(t *testing.T) {
 	type NestedPointerCopy NestedPointer
 	type MapCopy Map
 
+	testTime, _ := time.Parse("2006-01-02 15:04:05", "2022-03-21 12:03:03")
+
 	tests := []struct {
 		name    string
 		in      interface{}
@@ -2054,6 +2057,21 @@ func TestDecodeTable(t *testing.T) {
 			},
 			&map[string]interface{}{},
 			&map[string]interface{}{"visible": nil},
+			false,
+		},
+		{
+			"struct with time.Time to string",
+			&struct {
+				LogTime    time.Time `mapstructure:"logtime"`
+				CreateTime time.Time `mapstructure:"ctime,string"`
+				ModifyTime time.Time `mapstructure:"mtime,string,2006-01-02"`
+			}{
+				LogTime:    testTime,
+				CreateTime: testTime, // 2022-03-21 12:03:03
+				ModifyTime: testTime,
+			},
+			&map[string]interface{}{},
+			&map[string]interface{}{"logtime": testTime, "ctime": "2022-03-21 12:03:03", "mtime": "2022-03-21"},
 			false,
 		},
 	}

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2043,6 +2043,19 @@ func TestDecodeTable(t *testing.T) {
 			&map[string]interface{}{"visible": nil},
 			false,
 		},
+		{
+			"struct with omitvalue tag",
+			&struct {
+				VisibleField interface{} `mapstructure:"visible"`
+				OmitField    interface{} `mapstructure:"omittable,omitvalue:-1"`
+			}{
+				VisibleField: nil,
+				OmitField:    -1,
+			},
+			&map[string]interface{}{},
+			&map[string]interface{}{"visible": nil},
+			false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
add a tag "emitvalue", it like emitempty , but it can emit any value you want

            {
			"struct with omitvalue tag",
			&struct {
				VisibleField interface{} `mapstructure:"visible"`
				OmitField    interface{} `mapstructure:"omittable,omitvalue:-1"`
			}{
				VisibleField: nil,
				OmitField:    -1,
			},
			&map[string]interface{}{},
			&map[string]interface{}{"visible": nil},
			false,
		},
