### PR TITLE
DecoderConfig: Introduce `IgnoreUntaggedFields`

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -259,6 +259,10 @@ type DecoderConfig struct {
 	// defaults to "mapstructure"
 	TagName string
 
+	// IgnoreUntaggedFields ignores all struct fields without explicit
+	// TagName, comparable to `mapstructure:"-"` as default behaviour.
+	IgnoreUntaggedFields bool
+
 	// MatchName is the function used to match the map key to the struct
 	// field name or tag. Defaults to `strings.EqualFold`. This can be used
 	// to implement case-sensitive tag values, support snake casing, etc.
@@ -905,6 +909,10 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal reflect.Value, val re
 
 		tagValue := f.Tag.Get(d.config.TagName)
 		keyName := f.Name
+
+		if tagValue == "" && d.config.IgnoreUntaggedFields {
+			continue
+		}
 
 		// If Squash is set in the config, we squash the field down.
 		squash := d.config.Squash && v.Kind() == reflect.Struct && f.Anonymous

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2482,6 +2482,46 @@ func TestDecoder_MatchName(t *testing.T) {
 	}
 }
 
+func TestDecoder_IgnoreUntaggedFields(t *testing.T) {
+	type Input struct {
+		UntaggedNumber int
+		TaggedNumber   int `mapstructure:"tagged_number"`
+		UntaggedString string
+		TaggedString   string `mapstructure:"tagged_string"`
+	}
+	input := &Input{
+		UntaggedNumber: 31,
+		TaggedNumber:   42,
+		UntaggedString: "hidden",
+		TaggedString:   "visible",
+	}
+
+	actual := make(map[string]interface{})
+	config := &DecoderConfig{
+		Result:               &actual,
+		IgnoreUntaggedFields: true,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = decoder.Decode(input)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := map[string]interface{}{
+		"tagged_number": 42,
+		"tagged_string": "visible",
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Decode() expected: %#v\ngot: %#v", expected, actual)
+	}
+}
+
 func testSliceInput(t *testing.T, input map[string]interface{}, expected *Slice) {
 	var result Slice
 	err := Decode(input, &result)


### PR DESCRIPTION
This is to enable us to more easily (safely & predictably) serialize various structs representing [indexes in go-memdb](https://pkg.go.dev/github.com/hashicorp/go-memdb#Indexer), so that these can be displayed in a useful format in a (memdb) UI.

There are of course builtin indexes which wouldn't necessarily need such special decoding mode, but that assumes we gate the UI on a particular version of go-memdb which has these tags added. More importantly there are custom indexes downstream which may not have any tags and this makes decoded map unpredictable and hard to work with.
