### PR TITLE
Fix empty keyName when decoding struct -> map with omitempty

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -927,7 +927,9 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal reflect.Value, val re
 					return fmt.Errorf("cannot squash non-struct type '%s'", v.Type())
 				}
 			}
-			keyName = tagValue[:index]
+			if keyNameTagValue := tagValue[:index]; keyNameTagValue != "" {
+				keyName = keyNameTagValue
+			}
 		} else if len(tagValue) > 0 {
 			if tagValue == "-" {
 				continue

--- a/mapstructure_bugs_test.go
+++ b/mapstructure_bugs_test.go
@@ -1,6 +1,7 @@
 package mapstructure
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -599,5 +600,27 @@ func TestMapSquash(t *testing.T) {
 	}
 	if out.T.IsZero() {
 		t.Fatal("expected false")
+	}
+}
+
+// GH-238: Empty key name when decoding map from struct with only omitempty flag
+func TestMapOmitEmptyWithEmptyFieldnameInTag(t *testing.T) {
+	type Struct struct {
+		Username string `mapstructure:",omitempty"`
+		Age      int    `mapstructure:",omitempty"`
+	}
+
+	s := Struct{
+		Username: "Joe",
+	}
+	var m map[string]interface{}
+
+	if err := Decode(s, &m); err != nil {
+		t.Fatal(err)
+	}
+
+	expect := "map[Username:Joe]"
+	if got := fmt.Sprintf("%+v", m); expect != got {
+		t.Fatalf("expect %q, got: %s", expect, got)
 	}
 }


### PR DESCRIPTION
Fixes #238