### PR TITLE
Wrap decodehook errors when reporting

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -458,7 +458,7 @@ func (d *Decoder) decode(name string, input interface{}, outVal reflect.Value) e
 		var err error
 		input, err = DecodeHookExec(d.config.DecodeHook, inputVal, outVal)
 		if err != nil {
-			return fmt.Errorf("error decoding '%s': %s", name, err)
+			return fmt.Errorf("error decoding '%s': %w", name, err)
 		}
 	}
 


### PR DESCRIPTION
Allow mapstructure caller to use `errors.Is` and `errors.As` to determine the cause of errors returned by custom decode hooks.