### PR TITLE
Allow types to determine how to decode themselves

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -453,6 +453,13 @@ func (d *Decoder) decode(name string, input interface{}, outVal reflect.Value) e
 		return nil
 	}
 
+	if outVal.CanAddr() {
+		v := outVal.Addr()
+		if u, ok := v.Interface().(decoder); ok {
+			return u.Decode(input)
+		}
+	}
+
 	if d.config.DecodeHook != nil {
 		// We have a DecodeHook, so let's pre-process the input.
 		var err error
@@ -1539,4 +1546,8 @@ func dereferencePtrToStructIfNeeded(v reflect.Value, tagName string) reflect.Val
 		return deref
 	}
 	return v
+}
+
+type decoder interface {
+	Decode(interface{}) error
 }

--- a/mapstructure_examples_test.go
+++ b/mapstructure_examples_test.go
@@ -254,3 +254,32 @@ func ExampleDecode_omitempty() {
 	// Output:
 	// &map[Age:0 FirstName:Somebody]
 }
+
+type Someone struct {
+	Name string
+}
+
+func (p *Someone) Decode(v interface{}) error {
+	if name, ok := v.(string); ok {
+		p.Name = name
+		return nil
+	}
+	return fmt.Errorf("undecipherable name")
+}
+
+func ExampleDecode_custom_decoder_type() {
+	type Profile struct {
+		Friends []Someone
+	}
+	input := map[string]interface{}{
+		"friends": []string{"Mitchell"},
+	}
+	var result Profile
+	err := Decode(input, &result)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%#v", result)
+	// Output:
+	// mapstructure.Profile{Friends:[]mapstructure.Someone{mapstructure.Someone{Name:"Mitchell"}}}
+}


### PR DESCRIPTION
When the destination of a decode implements the custom decoder interface, use said interface. Custom decoders take precedence over the default decoding rules.

This should resolve #115 