### PR TITLE
Fix untagged field decoding in case of decode to struct

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -1358,6 +1358,9 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 		fieldName := field.Name
 
 		tagValue := field.Tag.Get(d.config.TagName)
+		if tagValue == "" && d.config.IgnoreUntaggedFields {
+			continue
+		}
 		tagValue = strings.SplitN(tagValue, ",", 2)[0]
 		if tagValue != "" {
 			fieldName = tagValue

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2732,6 +2732,44 @@ func TestDecoder_IgnoreUntaggedFields(t *testing.T) {
 	}
 }
 
+func TestDecoder_IgnoreUntaggedFieldsWithStruct(t *testing.T) {
+	type Output struct {
+		UntaggedInt    int
+		TaggedNumber   int `mapstructure:"tagged_number"`
+		UntaggedString string
+		TaggedString   string `mapstructure:"tagged_string"`
+	}
+	input := map[interface{}]interface{}{
+		"untaggedint":     31,
+		"tagged_number":   41,
+		"untagged_string": "hidden",
+		"tagged_string":   "visible",
+	}
+	actual := Output{}
+	config := &DecoderConfig{
+		Result:               &actual,
+		IgnoreUntaggedFields: true,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = decoder.Decode(input)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := Output{
+		TaggedNumber: 41,
+		TaggedString: "visible",
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Decode() expected: %#v\ngot: %#v", expected, actual)
+	}
+}
+
 func testSliceInput(t *testing.T, input map[string]interface{}, expected *Slice) {
 	var result Slice
 	err := Decode(input, &result)


### PR DESCRIPTION
When I try to decode data from `map[interface{}]interface{}` into struct with options `IgnoreUntaggedFields = true`, some fields at struct without `mapstructure` tag are still filling up. There is happend when key in map and filend name at struct are same.

Current pull request fix this issue.