### PR TITLE
Add a recovering decode hook

### DIFF
--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -99,6 +99,19 @@ func OrComposeDecodeHookFunc(ff ...DecodeHookFunc) DecodeHookFunc {
 	}
 }
 
+// RecoveringDecodeHookFunc executes the input hook function and turns a panic into an error.
+func RecoveringDecodeHookFunc(hook DecodeHookFunc) DecodeHookFunc {
+	return func(from, to reflect.Value) (v interface{}, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				v = nil
+				err = fmt.Errorf("internal error while parsing: %s", r)
+			}
+		}()
+		return DecodeHookExec(hook, from, to)
+	}
+}
+
 // StringToSliceHookFunc returns a DecodeHookFunc that converts
 // string to []string by splitting on the given sep.
 func StringToSliceHookFunc(sep string) DecodeHookFunc {


### PR DESCRIPTION
Hooks are difficult to get 100% correct. When there is an error in the code using reflection, we are likely to trigger a panic. While a panic is helpful to the developer, an end-user has no clue where the problem is and they don't know what part of the configuration would need to be tweaked to work around the issue.

The proposed recovering decode hook will turn the panic into an error, which is a more user-friendly way to report the error to an end user.