### PR TITLE
Fix Encoding Struct Back to Map Bug (#279)

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -956,6 +956,18 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal reflect.Value, val re
 				if v.Kind() != reflect.Struct {
 					return fmt.Errorf("cannot squash non-struct type '%s'", v.Type())
 				}
+			} else {
+				if strings.Index(tagValue[index+1:], "remain") != -1 {
+					if v.Kind() != reflect.Map {
+						return fmt.Errorf("error remain-tag field with invalid type: '%s'", v.Type())
+					}
+
+					ptr := v.MapRange()
+					for ptr.Next() {
+						valMap.SetMapIndex(ptr.Key(), ptr.Value())
+					}
+					continue
+				}
 			}
 			if keyNameTagValue := tagValue[:index]; keyNameTagValue != "" {
 				keyName = keyNameTagValue

--- a/mapstructure_benchmark_test.go
+++ b/mapstructure_benchmark_test.go
@@ -283,3 +283,29 @@ func Benchmark_DecodeTagged(b *testing.B) {
 		Decode(input, &result)
 	}
 }
+
+func Benchmark_DecodeWithRemainingFields(b *testing.B) {
+	type Person struct {
+		Name  string
+		Other map[string]interface{} `mapstructure:",remain"`
+	}
+
+	input := map[string]interface{}{
+		"name": "Luffy",
+		"age":  19,
+		"powers": []string{
+			"Rubber Man",
+			"Conqueror Haki",
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		// Decoding Map -> Struct
+		var person Person
+		_ = Decode(input, &person)
+
+		// Decoding Struct -> Map
+		result := make(map[string]interface{})
+		_ = Decode(&person, &result)
+	}
+}

--- a/mapstructure_examples_test.go
+++ b/mapstructure_examples_test.go
@@ -228,6 +228,41 @@ func ExampleDecode_remainingData() {
 	// mapstructure.Person{Name:"Mitchell", Age:91, Other:map[string]interface {}{"email":"mitchell@example.com"}}
 }
 
+func ExampleDecode_remainingDataDecodeBackToMapInFlatFormat() {
+	// Note that the mapstructure tags defined in the struct type
+	// can indicate which fields the values are mapped to.
+	type Person struct {
+		Name  string
+		Age   int
+		Other map[string]interface{} `mapstructure:",remain"`
+	}
+
+	input := map[string]interface{}{
+		"name": "Luffy",
+		"age":  19,
+		"powers": []string{
+			"Rubber Man",
+			"Conqueror Haki",
+		},
+	}
+
+	var person Person
+	err := Decode(input, &person)
+	if err != nil {
+		panic(err)
+	}
+
+	result := make(map[string]interface{})
+	err = Decode(&person, &result)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%#v", result)
+	// Output:
+	// map[string]interface {}{"Age":19, "Name":"Luffy", "powers":[]string{"Rubber Man", "Conqueror Haki"}}
+}
+
 func ExampleDecode_omitempty() {
 	// Add omitempty annotation to avoid map keys for empty values
 	type Family struct {

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2245,6 +2245,38 @@ func TestDecodeTable(t *testing.T) {
 			&map[string]interface{}{"visible": nil},
 			false,
 		},
+		{
+			"remainder with decode to map",
+			&Remainder{
+				A: "Alabasta",
+				Extra: map[string]interface{}{
+					"B": "Baratie",
+					"C": "Cocoyasi",
+				},
+			},
+			&map[string]interface{}{},
+			&map[string]interface{}{
+				"A": "Alabasta",
+				"B": "Baratie",
+				"C": "Cocoyasi",
+			},
+			false,
+		},
+		{
+			"remainder with decode to map with non-map field",
+			&struct {
+				A     string
+				Extra *struct{} `mapstructure:",remain"`
+			}{
+				A:     "Alabasta",
+				Extra: nil,
+			},
+			&map[string]interface{}{},
+			&map[string]interface{}{
+				"A": "Alabasta",
+			},
+			true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Motivation
[Issue](https://github.com/mitchellh/mapstructure/issues/279) #279 reported by @kszafran

# Changes
Check in `decode struct -> map` for extra fields encoded with `remain` tag, and flatten in resultant map. Add corresponding tests:
1. Unit test to decode struct (with remain-field) to map.
2. Unit test to check invalid remain-field type check error.
3. Example test to decode `map -> struct -> map`.
4. Benchmark test to decode `map -> struct -> map`.

# Summary
As extra fields are added to the remain-field while decoding map as structure, the reverse should work as well. i.e., while decoding structure as map, the extra fields in remain-field should get flattened in previous level. For code example, refer #279.

# Related Issues
Closes #279 