### PR TITLE
Fix: Wrong target type restriction when decoding struct to map #311

### DIFF
--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2788,6 +2788,70 @@ func testArrayInput(t *testing.T, input map[string]interface{}, expected *Array)
 	}
 }
 
+func TestDecode_structToGenericMap(t *testing.T) {
+	type SourceChild struct {
+		String string `mapstructure:"string"`
+	}
+
+	type SourceParent struct {
+		Child SourceChild `mapstructure:"child"`
+	}
+
+	var target map[string]interface{}
+
+	source := SourceParent{
+		Child: SourceChild{
+			String: "hello",
+		},
+	}
+
+	if err := Decode(source, &target); err != nil {
+		t.Fatalf("got error: %s", err)
+	}
+
+	expected := map[string]interface{}{
+		"child": map[string]interface{}{
+			"string": "hello",
+		},
+	}
+
+	if !reflect.DeepEqual(target, expected) {
+		t.Fatalf("bad: \nexpected: %#v\nresult: %#v", expected, target)
+	}
+}
+
+func TestDecode_structToTypedMap(t *testing.T) {
+	type SourceChild struct {
+		String string `mapstructure:"string"`
+	}
+
+	type SourceParent struct {
+		Child SourceChild `mapstructure:"child"`
+	}
+
+	var target map[string]map[string]interface{}
+
+	source := SourceParent{
+		Child: SourceChild{
+			String: "hello",
+		},
+	}
+
+	if err := Decode(source, &target); err != nil {
+		t.Fatalf("got error: %s", err)
+	}
+
+	expected := map[string]map[string]interface{}{
+		"child": {
+			"string": "hello",
+		},
+	}
+
+	if !reflect.DeepEqual(target, expected) {
+		t.Fatalf("bad: \nexpected: %#v\nresult: %#v", expected, target)
+	}
+}
+
 func stringPtr(v string) *string              { return &v }
 func intPtr(v int) *int                       { return &v }
 func uintPtr(v uint) *uint                    { return &v }

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2790,7 +2790,9 @@ func testArrayInput(t *testing.T, input map[string]interface{}, expected *Array)
 
 func TestDecode_structToGenericMap(t *testing.T) {
 	type SourceChild struct {
-		String string `mapstructure:"string"`
+		String string             `mapstructure:"string"`
+		Int    int                `mapstructure:"int"`
+		Map    map[string]float32 `mapstructure:"map"`
 	}
 
 	type SourceParent struct {
@@ -2802,6 +2804,11 @@ func TestDecode_structToGenericMap(t *testing.T) {
 	source := SourceParent{
 		Child: SourceChild{
 			String: "hello",
+			Int:    1,
+			Map: map[string]float32{
+				"one": 1.0,
+				"two": 2.0,
+			},
 		},
 	}
 
@@ -2812,6 +2819,11 @@ func TestDecode_structToGenericMap(t *testing.T) {
 	expected := map[string]interface{}{
 		"child": map[string]interface{}{
 			"string": "hello",
+			"int":    1,
+			"map": map[string]float32{
+				"one": 1.0,
+				"two": 2.0,
+			},
 		},
 	}
 
@@ -2822,7 +2834,9 @@ func TestDecode_structToGenericMap(t *testing.T) {
 
 func TestDecode_structToTypedMap(t *testing.T) {
 	type SourceChild struct {
-		String string `mapstructure:"string"`
+		String string             `mapstructure:"string"`
+		Int    int                `mapstructure:"int"`
+		Map    map[string]float32 `mapstructure:"map"`
 	}
 
 	type SourceParent struct {
@@ -2834,6 +2848,11 @@ func TestDecode_structToTypedMap(t *testing.T) {
 	source := SourceParent{
 		Child: SourceChild{
 			String: "hello",
+			Int:    1,
+			Map: map[string]float32{
+				"one": 1.0,
+				"two": 2.0,
+			},
 		},
 	}
 
@@ -2844,6 +2863,11 @@ func TestDecode_structToTypedMap(t *testing.T) {
 	expected := map[string]map[string]interface{}{
 		"child": {
 			"string": "hello",
+			"int":    1,
+			"map": map[string]float32{
+				"one": 1.0,
+				"two": 2.0,
+			},
 		},
 	}
 


### PR DESCRIPTION
This allows to map structures into typed maps. 
The typed map type must match the structure type.

Test have been added.