### PR TITLE
Add decode hooks for netip Addr and AddrPort

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.18.x, 1.19.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/decode_hooks_go1_18.go
+++ b/decode_hooks_go1_18.go
@@ -1,0 +1,47 @@
+//go:build go1.18
+// +build go1.18
+
+package mapstructure
+
+import (
+	"net/netip"
+	"reflect"
+)
+
+// StringToNetIPAddrHookFunc returns a DecodeHookFunc that converts
+// strings to netip.Addr.
+func StringToNetIPAddrHookFunc() DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		if t != reflect.TypeOf(netip.Addr{}) {
+			return data, nil
+		}
+
+		// Convert it by parsing
+		return netip.ParseAddr(data.(string))
+	}
+}
+
+// StringToNetIPAddrPortHookFunc returns a DecodeHookFunc that converts
+// strings to netip.AddrPort.
+func StringToNetIPAddrPortHookFunc() DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		if t != reflect.TypeOf(netip.AddrPort{}) {
+			return data, nil
+		}
+
+		// Convert it by parsing
+		return netip.ParseAddrPort(data.(string))
+	}
+}

--- a/decode_hooks_go1_18_test.go
+++ b/decode_hooks_go1_18_test.go
@@ -1,0 +1,66 @@
+//go:build go1.18
+// +build go1.18
+
+package mapstructure
+
+import (
+	"net/netip"
+	"reflect"
+	"testing"
+)
+
+func TestStringToNetIPAddrHookFunc(t *testing.T) {
+	strValue := reflect.ValueOf("5")
+	addrValue := reflect.ValueOf(netip.Addr{})
+	cases := []struct {
+		f, t   reflect.Value
+		result interface{}
+		err    bool
+	}{
+		{reflect.ValueOf("192.0.2.1"), addrValue,
+			netip.AddrFrom4([4]byte{0xc0, 0x00, 0x02, 0x01}), false},
+		{strValue, addrValue, netip.Addr{}, true},
+		{strValue, strValue, "5", false},
+	}
+
+	for i, tc := range cases {
+		f := StringToNetIPAddrHookFunc()
+		actual, err := DecodeHookExec(f, tc.f, tc.t)
+		if tc.err != (err != nil) {
+			t.Fatalf("case %d: expected err %#v", i, tc.err)
+		}
+		if !reflect.DeepEqual(actual, tc.result) {
+			t.Fatalf(
+				"case %d: expected %#v, got %#v",
+				i, tc.result, actual)
+		}
+	}
+}
+
+func TestStringToNetIPAddrPortHookFunc(t *testing.T) {
+	strValue := reflect.ValueOf("5")
+	addrPortValue := reflect.ValueOf(netip.AddrPort{})
+	cases := []struct {
+		f, t   reflect.Value
+		result interface{}
+		err    bool
+	}{
+		{reflect.ValueOf("192.0.2.1:80"), addrPortValue,
+			netip.AddrPortFrom(netip.AddrFrom4([4]byte{0xc0, 0x00, 0x02, 0x01}), 80), false},
+		{strValue, addrPortValue, netip.AddrPort{}, true},
+		{strValue, strValue, "5", false},
+	}
+
+	for i, tc := range cases {
+		f := StringToNetIPAddrPortHookFunc()
+		actual, err := DecodeHookExec(f, tc.f, tc.t)
+		if tc.err != (err != nil) {
+			t.Fatalf("case %d: expected err %#v", i, tc.err)
+		}
+		if !reflect.DeepEqual(actual, tc.result) {
+			t.Fatalf(
+				"case %d: expected %#v, got %#v",
+				i, tc.result, actual)
+		}
+	}
+}


### PR DESCRIPTION
Technically this package still supports Go 1.14 which is why I decided to add a guard for the new functions. I can easily get rid of it, but I'd recommend bumping the Go version in the go.mod file in that case.