### PR TITLE
Remove shell sign from code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ structure.
 
 Standard `go get`:
 
-```
-$ go get github.com/mitchellh/mapstructure
+```sh
+go get github.com/mitchellh/mapstructure
+FOO=bar
 ```
 
 ## Usage & Example


### PR DESCRIPTION
For easier copy-paste. GitHub automatically adds a "copy" button on code blocks, and without this change the dollar sign is also copied.