### PR TITLE
Prettify nested error messages

### DIFF
--- a/error.go
+++ b/error.go
@@ -16,12 +16,14 @@ type Error struct {
 func (e *Error) Error() string {
 	points := make([]string, len(e.Errors))
 	for i, err := range e.Errors {
+		// split by newlines and indent each line
+		err = strings.Replace(err, "\n", "\n  ", -1)
 		points[i] = fmt.Sprintf("* %s", err)
 	}
 
 	sort.Strings(points)
 	return fmt.Sprintf(
-		"%d error(s) decoding:\n\n%s",
+		"%d error(s) decoding:\n%s",
 		len(e.Errors), strings.Join(points, "\n"))
 }
 

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -1441,7 +1441,12 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 		}
 		sort.Strings(keys)
 
-		err := fmt.Errorf("'%s' has invalid keys: %s", name, strings.Join(keys, ", "))
+		var err error
+		if name == "" {
+			err = fmt.Errorf("invalid keys: %s", strings.Join(keys, ", "))
+		} else {
+			err = fmt.Errorf("'%s' has invalid keys: %s", name, strings.Join(keys, ", "))
+		}
 		errors = appendErrors(errors, err)
 	}
 


### PR DESCRIPTION
When using custom hooks and calling multiple decode functions, error output is not really human readable:

```
19 error(s) decoding:

* '' has invalid keys: log
* cannot parse 'transport.disable_compression' as bool: strconv.ParseBool: parsing "<bool>": invalid syntax
* cannot parse 'transport.disable_keep_alives' as bool: strconv.ParseBool: parsing "<bool>": invalid syntax
* cannot parse 'transport.force_attempt_http2' as bool: strconv.ParseBool: parsing "<bool>": invalid syntax
* cannot parse 'transport.max_conns_per_host' as int: strconv.ParseInt: parsing "<int>": invalid syntax
* cannot parse 'transport.max_idle_conns' as int: strconv.ParseInt: parsing "<int>": invalid syntax
* cannot parse 'transport.max_idle_conns_per_host' as int: strconv.ParseInt: parsing "<int>": invalid syntax
* cannot parse 'transport.max_response_header_bytes' as int: strconv.ParseInt: parsing "<int64>": invalid syntax
* cannot parse 'transport.read_buffer_size' as int: strconv.ParseInt: parsing "<int>": invalid syntax
* cannot parse 'transport.write_buffer_size' as int: strconv.ParseInt: parsing "<int>": invalid syntax
* error decoding 'proxy.middlewares[0]': failed to unmarshal provider cache: 1 error(s) decoding:

* error decoding 'provider': failed to unmarshal provider memory: 1 error(s) decoding:

* '' has invalid keys: ttl
* error decoding 'proxy.providers[1]': failed to unmarshal provider http: 1 error(s) decoding:

* '' has invalid keys: proxy
* error decoding 'proxy.providers[2]': failed to unmarshal provider hls: 1 error(s) decoding:

* error decoding 'proxy.middlewares[0]': failed to unmarshal provider cache: 1 error(s) decoding:

* error decoding 'provider': failed to unmarshal provider memory: 1 error(s) decoding:

* '' has invalid keys: ttl
* error decoding 'transport.dial_keep_alive': time: invalid duration "<time.Duration>"
* error decoding 'transport.dial_timeout': time: invalid duration "<time.Duration>"
* error decoding 'transport.expect_continue_timeout': time: invalid duration "<time.Duration>"
* error decoding 'transport.idle_conn_timeout': time: invalid duration "<time.Duration>"
* error decoding 'transport.response_header_timeout': time: invalid duration "<time.Duration>"
* error decoding 'transport.tls_handshake_timeout': time: invalid duration "<time.Duration>"
```

Changing to more readable format:

```
command execution finished with error: failed to unmarshal service config: 19 error(s) decoding:
* cannot parse 'transport.disable_compression' as bool: strconv.ParseBool: parsing "<bool>": invalid syntax
* cannot parse 'transport.disable_keep_alives' as bool: strconv.ParseBool: parsing "<bool>": invalid syntax
* cannot parse 'transport.force_attempt_http2' as bool: strconv.ParseBool: parsing "<bool>": invalid syntax
* cannot parse 'transport.max_conns_per_host' as int: strconv.ParseInt: parsing "<int>": invalid syntax
* cannot parse 'transport.max_idle_conns' as int: strconv.ParseInt: parsing "<int>": invalid syntax
* cannot parse 'transport.max_idle_conns_per_host' as int: strconv.ParseInt: parsing "<int>": invalid syntax
* cannot parse 'transport.max_response_header_bytes' as int: strconv.ParseInt: parsing "<int64>": invalid syntax
* cannot parse 'transport.read_buffer_size' as int: strconv.ParseInt: parsing "<int>": invalid syntax
* cannot parse 'transport.write_buffer_size' as int: strconv.ParseInt: parsing "<int>": invalid syntax
* error decoding 'proxy.middlewares[0]': failed to unmarshal provider cache: 1 error(s) decoding:
  * error decoding 'provider': failed to unmarshal provider memory: 1 error(s) decoding:
    * invalid keys: ttl
* error decoding 'proxy.providers[1]': failed to unmarshal provider http: 1 error(s) decoding:
  * invalid keys: proxy
* error decoding 'proxy.providers[2]': failed to unmarshal provider hls: 1 error(s) decoding:
  * error decoding 'proxy.middlewares[0]': failed to unmarshal provider cache: 1 error(s) decoding:
    * error decoding 'provider': failed to unmarshal provider memory: 1 error(s) decoding:
      * invalid keys: ttl
* error decoding 'transport.dial_keep_alive': time: invalid duration "<time.Duration>"
* error decoding 'transport.dial_timeout': time: invalid duration "<time.Duration>"
* error decoding 'transport.expect_continue_timeout': time: invalid duration "<time.Duration>"
* error decoding 'transport.idle_conn_timeout': time: invalid duration "<time.Duration>"
* error decoding 'transport.response_header_timeout': time: invalid duration "<time.Duration>"
* error decoding 'transport.tls_handshake_timeout': time: invalid duration "<time.Duration>"
```